### PR TITLE
Try to prevent Crowdin from breaking iframes in mdx files

### DIFF
--- a/layout/MDXLayout.tsx
+++ b/layout/MDXLayout.tsx
@@ -53,17 +53,15 @@ const mdxStyles = {
     display: 'block',
     textAlign: 'center',
   },
-  '.video-iframe, .video-container': {
-    display: 'block',
+  '.video-container': {
+    paddingBottom: `${100 / (16 / 9)}%`,
+  },
+  '.video-iframe': {
+    position: 'absolute',
+    left: 0,
+    top: 0,
     width: '100%',
-    aspectRatio: '16/9',
-    '& iframe': {
-      position: 'absolute',
-      left: 0,
-      top: 0,
-      width: '100%',
-      height: '100%',
-    },
+    height: '100%',
   },
 } as ThemeUIStyleObject
 

--- a/pages/ar/curating.mdx
+++ b/pages/ar/curating.mdx
@@ -95,10 +95,12 @@ title: (التنسيق) curating
 
 لازلت مشوشا؟ راجع فيديو دليل التنسيق أدناه:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/VytTEcf0dxQ"
-  title="مشغل فيديو يوتيوب"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/VytTEcf0dxQ"
+    title="مشغل فيديو يوتيوب"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>

--- a/pages/ar/delegating.mdx
+++ b/pages/ar/delegating.mdx
@@ -78,5 +78,11 @@ Using this formula, we can see that it is actually possible for an indexer who i
 باستخدام هذه الصيغة ، يمكننا أن نرى أنه من الممكن فعليا للمفهرس الذي يقدم 20٪ فقط للمفوضين ، أن يمنح المفوضين مكافأة أفضل من المفهرس الذي يعطي 90٪ للمفوضين.
 
 <figure className="video-container">
-  <iframe className="video-iframe" src="https://www.youtube.com/embed/2G7S2gdURdc" frameBorder="0" allowFullScreen />
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/2G7S2gdURdc"
+    title="مشغل فيديو يوتيوب"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
 </figure>

--- a/pages/ar/explorer.mdx
+++ b/pages/ar/explorer.mdx
@@ -11,7 +11,7 @@ title: مستكشف
     title="مشغل فيديو يوتيوب"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ## Subgraphs

--- a/pages/ar/hosted-service/migrating-subgraph.mdx
+++ b/pages/ar/hosted-service/migrating-subgraph.mdx
@@ -135,13 +135,15 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/CzdQ3dFFrjo"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/CzdQ3dFFrjo"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>
 
 - [The Graph Network Contracts](https://github.com/graphprotocol/contracts)
 - [Curation Contract](https://github.com/graphprotocol/contracts/blob/dev/contracts/curation/Curation.sol) - the underlying contract that the GNS wraps around

--- a/pages/ar/studio/billing.mdx
+++ b/pages/ar/studio/billing.mdx
@@ -48,7 +48,7 @@ For a quick demo of how billing works on the Subgraph Studio, check out the vide
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ### Multisig Users

--- a/pages/ar/studio/subgraph-studio.mdx
+++ b/pages/ar/studio/subgraph-studio.mdx
@@ -74,7 +74,7 @@ You’ve made it this far - congrats! Publishing your subgraph means that an IPF
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 Remember, while you’re going through your publishing flow, you’ll be able to push to either mainnet or Rinkeby, the testnet we support. If you’re a first time subgraph developer, we highly suggest you start with publishing to Rinkeby, which is free to do. This will allow you to see how the subgraph will work in The Graph Explorer and will allow you to test curation elements.

--- a/pages/en/curating.mdx
+++ b/pages/en/curating.mdx
@@ -93,10 +93,12 @@ Curation shares cannot be "bought" or "sold" like other ERC20 tokens that you ma
 
 Still confused? Check out our Curation video guide below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/VytTEcf0dxQ"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/VytTEcf0dxQ"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>

--- a/pages/en/delegating.mdx
+++ b/pages/en/delegating.mdx
@@ -84,5 +84,11 @@ Therefore a delegator should always consider the Delegation Capacity of an Index
 This guide provides a full review of this document, and how to consider everything in this document while interacting with the UI.
 
 <figure className="video-container">
-  <iframe className="video-iframe" src="https://www.youtube.com/embed/2G7S2gdURdc" frameBorder="0" allowFullScreen />
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/2G7S2gdURdc"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
 </figure>

--- a/pages/en/explorer.mdx
+++ b/pages/en/explorer.mdx
@@ -11,7 +11,7 @@ Welcome to the Graph Explorer, or as we like to call it, your decentralized port
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ## Subgraphs

--- a/pages/en/hosted-service/migrating-subgraph.mdx
+++ b/pages/en/hosted-service/migrating-subgraph.mdx
@@ -135,13 +135,15 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/CzdQ3dFFrjo"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/CzdQ3dFFrjo"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>
 
 - [The Graph Network Contracts](https://github.com/graphprotocol/contracts)
 - [Curation Contract](https://github.com/graphprotocol/contracts/blob/dev/contracts/curation/Curation.sol) - the underlying contract that the GNS wraps around

--- a/pages/en/studio/billing.mdx
+++ b/pages/en/studio/billing.mdx
@@ -48,7 +48,7 @@ For a quick demo of how billing works on the Subgraph Studio, check out the vide
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ### Multisig Users

--- a/pages/en/studio/subgraph-studio.mdx
+++ b/pages/en/studio/subgraph-studio.mdx
@@ -74,7 +74,7 @@ You’ve made it this far - congrats! Publishing your subgraph means that an IPF
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 Remember, while you’re going through your publishing flow, you’ll be able to push to either mainnet or Rinkeby, the testnet we support. If you’re a first time subgraph developer, we highly suggest you start with publishing to Rinkeby, which is free to do. This will allow you to see how the subgraph will work in The Graph Explorer and will allow you to test curation elements.

--- a/pages/es/curating.mdx
+++ b/pages/es/curating.mdx
@@ -95,10 +95,12 @@ Las participaciones de un curador no se pueden "comprar" o "vender" como otros t
 
 Still confused? Check out our Curation video guide below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/VytTEcf0dxQ"
-  title="Reproductor de video de YouTube"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/VytTEcf0dxQ"
+    title="Reproductor de video de YouTube"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>

--- a/pages/es/delegating.mdx
+++ b/pages/es/delegating.mdx
@@ -82,5 +82,11 @@ Por lo tanto, un delegador siempre debe considerar la Capacidad de Delegación d
 Utilizando está formula, podemos discernir qué un Indexer el cual está ofreciendo un rendimiento del 20% a sus delegados, puede estar ofreciendo un mejor rendimiento que aquél Indexador que ofrece un 90% a sus delegadores.
 
 <figure className="video-container">
-  <iframe className="video-iframe" src="https://www.youtube.com/embed/2G7S2gdURdc" frameBorder="0" allowFullScreen />
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/2G7S2gdURdc"
+    title="Reproductor de video de YouTube"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
 </figure>

--- a/pages/es/explorer.mdx
+++ b/pages/es/explorer.mdx
@@ -11,7 +11,7 @@ Bienvenido al explorador de The Graph, o como nos gusta llamarlo, tu portal desc
     title="Reproductor de video de YouTube"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ## Subgrafos

--- a/pages/es/hosted-service/migrating-subgraph.mdx
+++ b/pages/es/hosted-service/migrating-subgraph.mdx
@@ -135,13 +135,15 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/CzdQ3dFFrjo"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/CzdQ3dFFrjo"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>
 
 - [The Graph Network Contracts](https://github.com/graphprotocol/contracts)
 - [Curation Contract](https://github.com/graphprotocol/contracts/blob/dev/contracts/curation/Curation.sol) - the underlying contract that the GNS wraps around

--- a/pages/es/studio/billing.mdx
+++ b/pages/es/studio/billing.mdx
@@ -48,7 +48,7 @@ For a quick demo of how billing works on the Subgraph Studio, check out the vide
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ### Multisig Users

--- a/pages/es/studio/subgraph-studio.mdx
+++ b/pages/es/studio/subgraph-studio.mdx
@@ -74,7 +74,7 @@ You’ve made it this far - congrats! Publishing your subgraph means that an IPF
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 Remember, while you’re going through your publishing flow, you’ll be able to push to either mainnet or Rinkeby, the testnet we support. If you’re a first time subgraph developer, we highly suggest you start with publishing to Rinkeby, which is free to do. This will allow you to see how the subgraph will work in The Graph Explorer and will allow you to test curation elements.

--- a/pages/fr/curating.mdx
+++ b/pages/fr/curating.mdx
@@ -93,10 +93,12 @@ Curation shares cannot be "bought" or "sold" like other ERC20 tokens that you ma
 
 Still confused? Check out our Curation video guide below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/VytTEcf0dxQ"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/VytTEcf0dxQ"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>

--- a/pages/fr/delegating.mdx
+++ b/pages/fr/delegating.mdx
@@ -84,5 +84,11 @@ Therefore a delegator should always consider the Delegation Capacity of an Index
 This guide provides a full review of this document, and how to consider everything in this document while interacting with the UI.
 
 <figure className="video-container">
-  <iframe className="video-iframe" src="https://www.youtube.com/embed/2G7S2gdURdc" frameBorder="0" allowFullScreen />
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/2G7S2gdURdc"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
 </figure>

--- a/pages/fr/explorer.mdx
+++ b/pages/fr/explorer.mdx
@@ -11,7 +11,7 @@ Welcome to the Graph Explorer, or as we like to call it, your decentralized port
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ## Subgraphs

--- a/pages/fr/hosted-service/migrating-subgraph.mdx
+++ b/pages/fr/hosted-service/migrating-subgraph.mdx
@@ -135,13 +135,15 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/CzdQ3dFFrjo"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/CzdQ3dFFrjo"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>
 
 - [The Graph Network Contracts](https://github.com/graphprotocol/contracts)
 - [Curation Contract](https://github.com/graphprotocol/contracts/blob/dev/contracts/curation/Curation.sol) - the underlying contract that the GNS wraps around

--- a/pages/fr/studio/billing.mdx
+++ b/pages/fr/studio/billing.mdx
@@ -48,7 +48,7 @@ For a quick demo of how billing works on the Subgraph Studio, check out the vide
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ### Multisig Users

--- a/pages/fr/studio/subgraph-studio.mdx
+++ b/pages/fr/studio/subgraph-studio.mdx
@@ -74,7 +74,7 @@ You’ve made it this far - congrats! Publishing your subgraph means that an IPF
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 Remember, while you’re going through your publishing flow, you’ll be able to push to either mainnet or Rinkeby, the testnet we support. If you’re a first time subgraph developer, we highly suggest you start with publishing to Rinkeby, which is free to do. This will allow you to see how the subgraph will work in The Graph Explorer and will allow you to test curation elements.

--- a/pages/ja/curating.mdx
+++ b/pages/ja/curating.mdx
@@ -93,10 +93,12 @@ Migrating your curation shares to a new subgraph version incurs a curation tax o
 
 Still confused? その他の不明点に関しては、 以下のキュレーションビデオガイドをご覧ください：
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/VytTEcf0dxQ"
-  title="YouTubeビデオプレーヤー"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/VytTEcf0dxQ"
+    title="YouTubeビデオプレーヤー"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>

--- a/pages/ja/delegating.mdx
+++ b/pages/ja/delegating.mdx
@@ -81,5 +81,11 @@ A delegator can therefore do the math to determine that the Indexer offering 20%
 この式を使うと、デリゲーターに 20％しか提供していないインデクサーが、デリゲーターに 90％を提供しているインデクサーよりも、デリゲーターにさらに良い報酬を与えている可能性があることがわかります。
 
 <figure className="video-container">
-  <iframe className="video-iframe" src="https://www.youtube.com/embed/2G7S2gdURdc" frameBorder="0" allowFullScreen />
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/2G7S2gdURdc"
+    title="YouTubeビデオプレーヤー"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
 </figure>

--- a/pages/ja/explorer.mdx
+++ b/pages/ja/explorer.mdx
@@ -11,7 +11,7 @@ Welcome to the Graph Explorer, or as we like to call it, your decentralized port
     title="YouTube ビデオプレイヤー"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ## サブグラフ

--- a/pages/ja/hosted-service/migrating-subgraph.mdx
+++ b/pages/ja/hosted-service/migrating-subgraph.mdx
@@ -135,13 +135,15 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/CzdQ3dFFrjo"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/CzdQ3dFFrjo"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>
 
 - [The Graph Network Contracts](https://github.com/graphprotocol/contracts)
 - [Curation Contract](https://github.com/graphprotocol/contracts/blob/dev/contracts/curation/Curation.sol) - the underlying contract that the GNS wraps around

--- a/pages/ja/studio/billing.mdx
+++ b/pages/ja/studio/billing.mdx
@@ -48,7 +48,7 @@ For a quick demo of how billing works on the Subgraph Studio, check out the vide
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ### Multisig Users

--- a/pages/ja/studio/subgraph-studio.mdx
+++ b/pages/ja/studio/subgraph-studio.mdx
@@ -74,7 +74,7 @@ You’ve made it this far - congrats! Publishing your subgraph means that an IPF
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 Remember, while you’re going through your publishing flow, you’ll be able to push to either mainnet or Rinkeby, the testnet we support. If you’re a first time subgraph developer, we highly suggest you start with publishing to Rinkeby, which is free to do. This will allow you to see how the subgraph will work in The Graph Explorer and will allow you to test curation elements.

--- a/pages/ko/curating.mdx
+++ b/pages/ko/curating.mdx
@@ -93,10 +93,12 @@ title: 큐레이팅
 
 아직도 혼란스러우신가요? 아래의 큐레이션 비디오 가이드를 확인해보시길 바랍니다.
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/VytTEcf0dxQ"
-  title="YouTubeビデオプレーヤー"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/VytTEcf0dxQ"
+    title="YouTubeビデオプレーヤー"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>

--- a/pages/ko/delegating.mdx
+++ b/pages/ko/delegating.mdx
@@ -79,5 +79,11 @@ A delegator can therefore do the math to determine that the Indexer offering 20%
 이 공식을 사용하여, 우리는 실제로 위임자에게 20%만 제공하는 인덱서가 실제로 위임자에게 90%를 주는 인덱서보다 훨씬 더 나은 보상을 제공하는 것이 가능하다는 것을 알 수 있습니다.
 
 <figure className="video-container">
-  <iframe className="video-iframe" src="https://www.youtube.com/embed/2G7S2gdURdc" frameBorder="0" allowFullScreen />
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/2G7S2gdURdc"
+    title="YouTubeビデオプレーヤー"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
 </figure>

--- a/pages/ko/explorer.mdx
+++ b/pages/ko/explorer.mdx
@@ -11,7 +11,7 @@ title: 탐색기
     title="YouTubeビデオプレーヤー"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ## 서브그래프

--- a/pages/ko/hosted-service/migrating-subgraph.mdx
+++ b/pages/ko/hosted-service/migrating-subgraph.mdx
@@ -135,13 +135,15 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/CzdQ3dFFrjo"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/CzdQ3dFFrjo"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>
 
 - [The Graph Network Contracts](https://github.com/graphprotocol/contracts)
 - [Curation Contract](https://github.com/graphprotocol/contracts/blob/dev/contracts/curation/Curation.sol) - the underlying contract that the GNS wraps around

--- a/pages/ko/studio/billing.mdx
+++ b/pages/ko/studio/billing.mdx
@@ -48,7 +48,7 @@ For a quick demo of how billing works on the Subgraph Studio, check out the vide
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ### Multisig Users

--- a/pages/ko/studio/subgraph-studio.mdx
+++ b/pages/ko/studio/subgraph-studio.mdx
@@ -74,7 +74,7 @@ You’ve made it this far - congrats! Publishing your subgraph means that an IPF
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 Remember, while you’re going through your publishing flow, you’ll be able to push to either mainnet or Rinkeby, the testnet we support. If you’re a first time subgraph developer, we highly suggest you start with publishing to Rinkeby, which is free to do. This will allow you to see how the subgraph will work in The Graph Explorer and will allow you to test curation elements.

--- a/pages/zh/curating.mdx
+++ b/pages/zh/curating.mdx
@@ -93,10 +93,12 @@ Remember that curation is risky. 请做好你的工作，确保你在你信任�
 
 还有困惑吗？ 点击下面查看策展视频指导：
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/VytTEcf0dxQ"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/VytTEcf0dxQ"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>

--- a/pages/zh/delegating.mdx
+++ b/pages/zh/delegating.mdx
@@ -78,5 +78,11 @@ A delegator can therefore do the math to determine that the Indexer offering 20%
 使用这个公式，我们可以看到实际上只向委托人提供 20％的索引人比给索引人提供 90％的索引人实际上给予委托人更好的奖励。
 
 <figure className="video-container">
-  <iframe className="video-iframe" src="https://www.youtube.com/embed/2G7S2gdURdc" frameBorder="0" allowFullScreen />
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/2G7S2gdURdc"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
 </figure>

--- a/pages/zh/explorer.mdx
+++ b/pages/zh/explorer.mdx
@@ -11,7 +11,7 @@ title: 浏览器
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ## 子图

--- a/pages/zh/hosted-service/migrating-subgraph.mdx
+++ b/pages/zh/hosted-service/migrating-subgraph.mdx
@@ -135,13 +135,15 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
 
-<iframe
-  className="video-iframe"
-  src="https://www.youtube.com/embed/CzdQ3dFFrjo"
-  title="YouTube video player"
-  frameBorder="0"
-  allowFullScreen
-/>
+<figure className="video-container">
+  <iframe
+    className="video-iframe"
+    src="https://www.youtube.com/embed/CzdQ3dFFrjo"
+    title="YouTube video player"
+    frameBorder="0"
+    allowFullScreen
+  ></iframe>
+</figure>
 
 - [The Graph Network Contracts](https://github.com/graphprotocol/contracts)
 - [Curation Contract](https://github.com/graphprotocol/contracts/blob/dev/contracts/curation/Curation.sol) - the underlying contract that the GNS wraps around

--- a/pages/zh/studio/billing.mdx
+++ b/pages/zh/studio/billing.mdx
@@ -48,7 +48,7 @@ For a quick demo of how billing works on the Subgraph Studio, check out the vide
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 ### Multisig Users

--- a/pages/zh/studio/subgraph-studio.mdx
+++ b/pages/zh/studio/subgraph-studio.mdx
@@ -74,7 +74,7 @@ You’ve made it this far - congrats! Publishing your subgraph means that an IPF
     title="YouTube video player"
     frameBorder="0"
     allowFullScreen
-  />
+  ></iframe>
 </figure>
 
 Remember, while you’re going through your publishing flow, you’ll be able to push to either mainnet or Rinkeby, the testnet we support. If you’re a first time subgraph developer, we highly suggest you start with publishing to Rinkeby, which is free to do. This will allow you to see how the subgraph will work in The Graph Explorer and will allow you to test curation elements.


### PR DESCRIPTION
So it doesn’t do things like [this](https://github.com/graphprotocol/docs/pull/7/commits/48c6e855c599da1c43af302e4cd68ad5c664557a#diff-5969f05496780a313f5ac95fffdd4909e8a6285336b38f595fd4b1a3359a3518R103) anymore.