### PR TITLE
Fixed `json.fromString` type definition

### DIFF
--- a/pages/en/developer/assemblyscript-api.mdx
+++ b/pages/en/developer/assemblyscript-api.mdx
@@ -621,10 +621,10 @@ import { json, JSONValueKind } from '@graphprotocol/graph-ts'
 
 JSON data can be parsed using the `json` API:
 
-- `json.fromBytes(data: Bytes): JSONValue` – parses JSON data from a `Bytes` array
+- `json.fromBytes(data: Bytes): JSONValue` – parses JSON data from a `Bytes` array interpreted as a valid UTF-8 sequence
 - `json.try_fromBytes(data: Bytes): Result<JSONValue, boolean>` – safe version of `json.fromBytes`, it returns an error variant if the parsing failed
-- `json.fromString(data: Bytes): JSONValue` – parses JSON data from a valid UTF-8 `String`
-- `json.try_fromString(data: Bytes): Result<JSONValue, boolean>` – safe version of `json.fromString`, it returns an error variant if the parsing failed
+- `json.fromString(data: string): JSONValue` – parses JSON data from a valid UTF-8 `String`
+- `json.try_fromString(data: string): Result<JSONValue, boolean>` – safe version of `json.fromString`, it returns an error variant if the parsing failed
 
 The `JSONValue` class provides a way to pull values out of an arbitrary JSON document. Since JSON values can be booleans, numbers, arrays and more, `JSONValue` comes with a `kind` property to check the type of a value:
 


### PR DESCRIPTION
Also added an extra detail to `Bytes` version