### PR TITLE
Add `workflow_dispatch` event trigger to `ci-cd-staging` workflow

### DIFF
--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -1,6 +1,7 @@
 name: Staging CI/CD
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This should allow us to manually deploy any branch to staging from the GitHub Actions UI.