### PR TITLE
Fix AS Migration Guide upcasting code snippet

### DIFF
--- a/pages/en/developer/assemblyscript-migration-guide.mdx
+++ b/pages/en/developer/assemblyscript-migration-guide.mdx
@@ -180,7 +180,8 @@ let c: usize = a + (b as usize)
 // upcasting on class inheritance
 class Bytes extends Uint8Array {}
 
-let bytes = new Bytes(2) < Uint8Array > bytes // same as: bytes as Uint8Array
+let bytes = new Bytes(2)
+// <Uint8Array>bytes // same as: bytes as Uint8Array
 ```
 
 There are two scenarios where you may want to cast, but using `as`/`<T>var` **isn't safe**:
@@ -192,7 +193,8 @@ There are two scenarios where you may want to cast, but using `as`/`<T>var` **is
 // downcasting on class inheritance
 class Bytes extends Uint8Array {}
 
-let uint8Array = new Uint8Array(2) < Bytes > uint8Array // breaks in runtime :(
+let uint8Array = new Uint8Array(2)
+// <Bytes>uint8Array // breaks in runtime :(
 ```
 
 ```typescript
@@ -200,7 +202,8 @@ let uint8Array = new Uint8Array(2) < Bytes > uint8Array // breaks in runtime :(
 class Bytes extends Uint8Array {}
 class ByteArray extends Uint8Array {}
 
-let bytes = new Bytes(2) < ByteArray > bytes // breaks in runtime :(
+let bytes = new Bytes(2)
+// <ByteArray>bytes // breaks in runtime :(
 ```
 
 For those cases, you can use the `changetype<T>` function:


### PR DESCRIPTION
At some point in the internationalization of the docs, some code got it's formatting broken.

This PR fixes this issue only for the AssemblyScript Migration Guide.

Some of the fixes include:

- Adding semicolons to the code
- Fixing casting examples
- Adding deleted comments in translations
- Fixing compiler error messages in translations
