### PR TITLE
Fixing typo in conversion function BigInt

### DIFF
--- a/pages/en/developer/assemblyscript-api.mdx
+++ b/pages/en/developer/assemblyscript-api.mdx
@@ -671,7 +671,7 @@ When the type of a value is certain, it can be converted to a [built-in type](#b
 | Bytes                | JSON                 | json.fromBytes(s)            |
 | int8                 | i32                  | none                         |
 | int32                | i32                  | none                         |
-| int32                | BigInt               | Bigint.fromI32(s)            |
+| int32                | BigInt               | BigInt.fromI32(s)            |
 | uint24               | i32                  | none                         |
 | int64 - int256       | BigInt               | none                         |
 | uint32 - uint256     | BigInt               | none                         |


### PR DESCRIPTION
In the conversion table, the row

`int32 | BigInt | Bigint.fromI32(s)`

should be:

`int32 | BigInt | BigInt.fromI32(s)`
