### PR TITLE
docs(create-subgraph-hosted): fix enabling non-fatal errors example manifest

### DIFF
--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -862,7 +862,7 @@ Enabling non-fatal errors requires setting the following feature flag on the sub
 specVersion: 0.0.4
 description: Gravatar for Ethereum
 features:
-    - fullTextSearch
+    - nonFatalErrors
     ...
 ```
 


### PR DESCRIPTION
Features contained `fullTextSearch` instead of `nonFatalErrors`