### PR TITLE
[update] Reverse Lookups. Many-to-many examples

### DIFF
--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -333,7 +333,7 @@ A more performant way to store this relationship is through a mapping table that
 type Organization @entity {
   id: ID!
   name: String!
-  members: [UserOrganization]! @derivedFrom(field: "organization")
+  members: [UserOrganization!]! @derivedFrom(field: "organization")
 }
 
 type User @entity {


### PR DESCRIPTION
With latest `@graphprotocol/graph-cli@0.28.1` and `@graphprotocol/graph-ts@0.26.0`, GraphQL schemas can't have Lists which nullable members. 
Basically solves by changing `[UserOrganization]!` to `[UserOrganization!]!`