### PR TITLE
Document apiVersion 0.0.7, specVersion 0.0.5 and receipts in mappings

### DIFF
--- a/pages/en/developer/assemblyscript-api.mdx
+++ b/pages/en/developer/assemblyscript-api.mdx
@@ -45,6 +45,7 @@ The `apiVersion` in the subgraph manifest specifies the mapping API version whic
 
 | Version | Release notes |
 | :-: | --- |
+| 0.0.7 | Added `TransactionReceipt` and `Log` classes to the Ethereum types<br />Added `receipt` field to the Ethereum Event object|
 | 0.0.6 | Added `nonce` field to the Ethereum Transaction object<br />Added `baseFeePerGas` to the Ethereum Block object |
 | 0.0.5 | AssemblyScript upgraded to version 0.19.10 (this includes breaking changes, please see the [`Migration Guide`](/developer/assemblyscript-migration-guide))<br />`ethereum.transaction.gasUsed` renamed to `ethereum.transaction.gasLimit` |
 | 0.0.4 | Added `functionSignature` field to the Ethereum SmartContractCall object |
@@ -357,6 +358,7 @@ class Event {
   block: Block
   transaction: Transaction
   parameters: Array<EventParam>
+  receipt: TransactionReceipt | null
 }
 
 class Block {

--- a/pages/en/developer/assemblyscript-api.mdx
+++ b/pages/en/developer/assemblyscript-api.mdx
@@ -390,6 +390,34 @@ class Transaction {
   input: Bytes
   nonce: BigInt
 }
+
+class TransactionReceipt {
+  transactionHash: Bytes
+  transactionIndex: BigInt
+  blockHash: Bytes
+  blockNumber: BigInt
+  cumulativeGasUsed: BigInt
+  gasUsed: BigInt
+  contractAddress: Address
+  logs: Array<Log>
+  status: BigInt
+  root: Bytes
+  logsBloom: Bytes
+ }
+
+class Log {
+  address: Address
+  topics: Array<Bytes>
+  data: Bytes
+  blockHash: Bytes
+  blockNumber: Bytes
+  transactionHash: Bytes
+  transactionIndex: BigInt
+  logIndex: BigInt
+  transactionLogIndex: BigInt
+  logType: string
+  removed: bool | null
+}
 ```
 
 #### Access to Smart Contract State

--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -816,7 +816,7 @@ An event will only be triggered when both the signature and topic 0 match. By de
 
 Starting from `specVersion` `0.0.5` and `apiVersion` `0.0.7`, event handlers can have access to the receipt for the transaction which emitted them.
 
-To do so, event handlers must be declared in the subgraph manifest with thenew `receipt: true` key, which is optional and defaults to false.
+To do so, event handlers must be declared in the subgraph manifest with the new `receipt: true` key, which is optional and defaults to false.
 
 ```yaml
 eventHandlers:

--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -812,6 +812,22 @@ eventHandlers:
 
 An event will only be triggered when both the signature and topic 0 match. By default, `topic0` is equal to the hash of the event signature.
 
+## Transaction Receipts in Event Handlers
+
+Starting from `specVersion` `0.0.5` and `apiVersion` `0.0.7`, event handlers can have access to the receipt for the transaction which emitted them.
+
+To do so, event handlers must be declared in the subgraph manifest with thenew `receipt: true` key, which is optional and defaults to false.
+
+```yaml
+eventHandlers:
+  - event: NewGravatar(uint256,address,string,string)
+    handler: handleNewGravatar
+    receipt: true
+```
+
+Inside the handler function, the receipt can be accessed in the `Event.receipt` field. When the `receipt` key is set to `false` or omitted in the manifest, a `null` value will be returned instead.
+
+
 ## Experimental features
 
 Starting from `specVersion` `0.0.4`, subgraph features must be explicitly declared in the `features` section at the top level of the manifest file, using their `camelCase` name, as listed in the table below:


### PR DESCRIPTION
This PR briefly documents the changes introduced in https://github.com/graphprotocol/graph-node/pull/3373.


I'm not sure if those changes are enough for it to be considered to be final, so I'll be happy to refine this PR based on the team's suggestions.

The feature PR linked above contains lots of extra detail if more context is needed.