### PR TITLE
Make debug forking docs stable :)

### DIFF
--- a/navigation/navigation.ts
+++ b/navigation/navigation.ts
@@ -58,6 +58,9 @@ export const navigation: (locale: AppLocale) => NavItemDefinition[] = (locale) =
         slug: 'matchstick',
       },
       {
+        slug: 'subgraph-debug-forking',
+      },
+      {
         slug: 'deprecating-a-subgraph',
       },
       {

--- a/pages/en/developer/subgraph-debug-forking.mdx
+++ b/pages/en/developer/subgraph-debug-forking.mdx
@@ -2,8 +2,6 @@
 title: Quick and easy subgraph debugging using forks
 ---
 
-> Note: this is only available from this `graph-node` [commit](https://github.com/graphprotocol/graph-node/commit/f4e6992d7949b18f990045c8babdcd205a060ef6) or this [docker tag](https://hub.docker.com/layers/graphprotocol/graph-node/f4e6992/images/sha256-51ad494a2ecc387bef2359d863b596ad5bd44436808964cf221e60365a7c00c8?context=explore) onwards, it hasn't been yet released in a minor release (eg: 0.26.0)
-
 As with many systems processing large amounts of data, The Graph's Indexers (Graph nodes) may take quite some time to sync-up your subgraph with the target blockchain. The discrepancy between quick changes with the purpose of debugging and long wait times needed for indexing is extremely counterproductive and we are well aware of that. This is why we are introducing **subgraph forking**, developed by [LimeChain](https://limechain.tech/), and in this article I will show you how this feature can be used to substantially speed-up subgraph debugging!
 
 ## Ok, what is it?


### PR DESCRIPTION
- Adds debug-forking to navigation bar again
- Removes v0.26.0 warning since it's out!

Reference: https://github.com/graphprotocol/graph-node/blob/master/NEWS.md#0260