### PR TITLE
Document `id: Bytes!` and immutable entities

### DIFF
--- a/pages/en/developer/assemblyscript-api.mdx
+++ b/pages/en/developer/assemblyscript-api.mdx
@@ -240,9 +240,8 @@ import { Transfer } from '../generated/schema'
 
 // Transfer event handler
 export function handleTransfer(event: TransferEvent): void {
-  // Create a Transfer entity, using the hexadecimal string representation
-  // of the transaction hash as the entity ID
-  let id = event.transaction.hash.toHex()
+  // Create a Transfer entity, using the transaction hash as the entity ID
+  let id = event.transaction.hash
   let transfer = new Transfer(id)
 
   // Set properties on the entity, using the event parameters
@@ -264,7 +263,7 @@ Each entity must have a unique ID to avoid collisions with other entities. It is
 If an entity already exists, it can be loaded from the store with the following:
 
 ```typescript
-let id = event.transaction.hash.toHex() // or however the ID is constructed
+let id = event.transaction.hash // or however the ID is constructed
 let transfer = Transfer.load(id)
 if (transfer == null) {
   transfer = new Transfer(id)
@@ -323,7 +322,7 @@ There is currently no way to remove an entity via the generated types. Instead, 
 ```typescript
 import { store } from '@graphprotocol/graph-ts'
 ...
-let id = event.transaction.hash.toHex()
+let id = event.transaction.hash
 store.remove('Transfer', id)
 ```
 
@@ -341,6 +340,7 @@ The following example illustrates this. Given a subgraph schema like
 
 ```graphql
 type Transfer @entity {
+  id: Bytes!
   from: Bytes!
   to: Bytes!
   amount: BigInt!
@@ -350,7 +350,7 @@ type Transfer @entity {
 and a `Transfer(address,address,uint256)` event signature on Ethereum, the `from`, `to` and `amount` values of type `address`, `address` and `uint256` are converted to `Address` and `BigInt`, allowing them to be passed on to the `Bytes!` and `BigInt!` properties of the `Transfer` entity:
 
 ```typescript
-let id = event.transaction.hash.toHex()
+let id = event.transaction.hash
 let transfer = new Transfer(id)
 transfer.from = event.params.from
 transfer.to = event.params.to
@@ -600,7 +600,7 @@ export function processItem(value: JSONValue, userData: Value): void {
   }
 
   // Callbacks can also created entities
-  let newItem = new Item(id.toString())
+  let newItem = new Item(id)
   newItem.title = title.toString()
   newitem.parent = userData.toString() // Set parent to "parentId"
   newitem.save()
@@ -667,7 +667,6 @@ When the type of a value is certain, it can be converted to a [built-in type](#b
 | Source(s)            | Destination          | Conversion function          |
 | -------------------- | -------------------- | ---------------------------- |
 | Address              | Bytes                | none                         |
-| Address              | ID                   | s.toHexString()              |
 | Address              | String               | s.toHexString()              |
 | BigDecimal           | String               | s.toString()                 |
 | BigInt               | BigDecimal           | s.toBigDecimal()             |

--- a/pages/en/developer/assemblyscript-api.mdx
+++ b/pages/en/developer/assemblyscript-api.mdx
@@ -81,7 +81,8 @@ _Type conversions_
 _Operators_
 
 - `equals(y: ByteArray): bool` – can be written as `x == y`.
-
+- `concat(other: ByteArray) : ByteArray` - return a new `ByteArray` consisting of `this` directly followed by `other`
+- `concatI32(other: i32) : ByteArray` - return a new `ByteArray` consisting of `this` directly follow by the byte representation of `other`
 #### BigDecimal
 
 ```typescript
@@ -187,9 +188,21 @@ import { Bytes } from '@graphprotocol/graph-ts'
 
 The `Bytes` class extends AssemblyScript's [Uint8Array](https://github.com/AssemblyScript/assemblyscript/blob/3b1852bc376ae799d9ebca888e6413afac7b572f/std/assembly/typedarray.ts#L64) and this supports all the `Uint8Array` functionality, plus the following new methods:
 
+_Construction_
+
+- `fromHexString(hex: string) : Bytes` - Convert the string `hex` which must consist of an even number of hexadecimal digits to a `ByteArray`. The string `hex` can optionally start with `0x`
+- `fromI32(i: i32) : Bytes` - Convert `i` to an array of bytes
+
+_Type conversions_
+
 - `b.toHex()` – returns a hexadecimal string representing the bytes in the array
 - `b.toString()` – converts the bytes in the array to a string of unicode characters
 - `b.toBase58()` – turns an Ethereum Bytes value to base58 encoding (used for IPFS hashes)
+
+_Operators_
+
+- `b.concat(other: Bytes) : Bytes` - - return new `Bytes` consisting of `this` directly followed by `other`
+- `b.concatI32(other: i32) : ByteArray` - return new `Bytes` consisting of `this` directly follow by the byte representation of `other`
 
 #### Address
 
@@ -202,6 +215,7 @@ import { Address } from '@graphprotocol/graph-ts'
 It adds the following method on top of the `Bytes` API:
 
 - `Address.fromString(s: string): Address` – creates an `Address` from a hexadecimal string
+- `Address.fromBytes(b: Bytes): Address` – create an `Address` from `b` which must be exactly 20 bytes long. Passing in a value with fewer or more bytes will result in an error
 
 ### Store API
 

--- a/pages/en/developer/assemblyscript-migration-guide.mdx
+++ b/pages/en/developer/assemblyscript-migration-guide.mdx
@@ -364,7 +364,7 @@ Also if you have nullable properties in a GraphQL entity, like this:
 
 ```graphql
 type Total @entity {
-  id: ID!
+  id: Bytes!
   amount: BigInt
 }
 ```
@@ -398,7 +398,7 @@ Or you can just change your GraphQL schema to not use a nullable type for this p
 
 ```graphql
 type Total @entity {
-  id: ID!
+  id: Bytes!
   amount: BigInt!
 }
 ```
@@ -489,11 +489,11 @@ Now you no longer can define fields in your types that are Non-Nullable Lists. I
 
 ```graphql
 type Something @entity {
-  id: ID!
+  id: Bytes!
 }
 
 type MyEntity @entity {
-  id: ID!
+  id: Bytes!
   invalidField: [Something]! # no longer valid
 }
 ```
@@ -502,11 +502,11 @@ You'll have to add an `!` to the member of the List type, like this:
 
 ```graphql
 type Something @entity {
-  id: ID!
+  id: Bytes!
 }
 
 type MyEntity @entity {
-  id: ID!
+  id: Bytes!
   invalidField: [Something!]! # valid
 }
 ```

--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -166,14 +166,14 @@ The schema for your subgraph is in the file `schema.graphql`. GraphQL schemas ar
 
 Before defining entities, it is important to take a step back and think about how your data is structured and linked. All queries will be made against the data model defined in the subgraph schema and the entities indexed by the subgraph. Because of this, it is good to define the subgraph schema in a way that matches the needs of your dapp. It may be useful to imagine entities as "objects containing data", rather than as events or functions.
 
-With The Graph, you simply define entity types in `schema.graphql`, and Graph Node will generate top level fields for querying single instances and collections of that entity type. Each type that should be an entity is required to be annotated with an `@entity` directive.
+With The Graph, you simply define entity types in `schema.graphql`, and Graph Node will generate top level fields for querying single instances and collections of that entity type. Each type that should be an entity is required to be annotated with an `@entity` directive. By default, entities are mutable, meaning that mappings can load existing entities, modify them and store a new version of that entity. Mutability comes at a price, and for entity types for which it is known that they will never be modified, for example, because they simply contain data extracted verbatim from the chain, it is recommended to mark them as immutable with `@entity(immutable: true)`. Mappings can make changes to immutable entities as long as those changes happen in the same block in which the entity was created. Immutable entities are much faster to write and to query, and should therefore be used whenever possible.
 
 ### Good Example
 
 The `Gravatar` entity below is structured around a Gravatar object and is a good example of how an entity could be defined.
 
 ```graphql
-type Gravatar @entity {
+type Gravatar @entity(immutable: true) {
   id: Bytes!
   owner: Bytes
   displayName: String
@@ -256,12 +256,12 @@ Relationships are defined on entities just like any other field except that the 
 Define a `Transaction` entity type with an optional one-to-one relationship with a `TransactionReceipt` entity type:
 
 ```graphql
-type Transaction @entity {
+type Transaction @entity(immutable: true) {
   id: Bytes!
   transactionReceipt: TransactionReceipt
 }
 
-type TransactionReceipt @entity {
+type TransactionReceipt @entity(immutable: true) {
   id: Bytes!
   transaction: Transaction
 }
@@ -272,7 +272,7 @@ type TransactionReceipt @entity {
 Define a `TokenBalance` entity type with a required one-to-many relationship with a Token entity type:
 
 ```graphql
-type Token @entity {
+type Token @entity(immutable: true) {
   id: Bytes!
 }
 
@@ -294,7 +294,7 @@ For one-to-many relationships, the relationship should always be stored on the '
 We can make the balances for a token accessible from the token by deriving a `tokenBalances` field:
 
 ```graphql
-type Token @entity {
+type Token @entity(immutable: true) {
   id: Bytes!
   tokenBalances: [TokenBalance!]! @derivedFrom(field: "token")
 }

--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -174,7 +174,7 @@ The `Gravatar` entity below is structured around a Gravatar object and is a good
 
 ```graphql
 type Gravatar @entity {
-  id: ID!
+  id: Bytes!
   owner: Bytes
   displayName: String
   imageUrl: String
@@ -188,14 +188,14 @@ The example `GravatarAccepted` and `GravatarDeclined` entities below are based a
 
 ```graphql
 type GravatarAccepted @entity {
-  id: ID!
+  id: Bytes!
   owner: Bytes
   displayName: String
   imageUrl: String
 }
 
 type GravatarDeclined @entity {
-  id: ID!
+  id: Bytes!
   owner: Bytes
   displayName: String
   imageUrl: String
@@ -210,7 +210,9 @@ Entity fields can be defined as required or optional. Required fields are indica
 Null value resolved for non-null field 'name'
 ```
 
-Each entity must have an `id` field, which is of type `ID!` (string). The `id` field serves as the primary key, and needs to be unique among all entities of the same type.
+Each entity must have an `id` field, which must be of type `Bytes!` or `String!`. It is generally recommended to use `Bytes!`, unless the `id` contains human-readable text, since entities with `Bytes!` id's will be faster to write and query as those with a `String!` `id`. The `id` field serves as the primary key, and needs to be unique among all entities of the same type. For historical reasons, the type `ID!` is also accepted and is a synonym for `String!`.
+
+For some entity types the `id` is constructed from the id's of two other entities; that is possible using `concat`, e.g., `let id = left.id.concat(right.id) ` to form the id from the id's of `left` and `right`. Similarly, to construct an id from the id of an existing entity and a counter `count`, `let id = left.id.concatI32(count)` can be used. The concatenation is guaranteed to produce unique id's as long as the length of `left` is the same for all such entities, for example, because `left.id` is an `Address`.
 
 ### Built-In Scalar Types
 
@@ -221,7 +223,6 @@ We support the following scalars in our GraphQL API:
 | Type | Description |
 | --- | --- |
 | `Bytes` | Byte array, represented as a hexadecimal string. Commonly used for Ethereum hashes and addresses. |
-| `ID` | Stored as a `string`. |
 | `String` | Scalar for `string` values. Null characters are not supported and are automatically removed. |
 | `Boolean` | Scalar for `boolean` values. |
 | `Int` | The GraphQL spec defines `Int` to have size of 32 bytes. |
@@ -256,12 +257,12 @@ Define a `Transaction` entity type with an optional one-to-one relationship with
 
 ```graphql
 type Transaction @entity {
-  id: ID!
+  id: Bytes!
   transactionReceipt: TransactionReceipt
 }
 
 type TransactionReceipt @entity {
-  id: ID!
+  id: Bytes!
   transaction: Transaction
 }
 ```
@@ -272,11 +273,11 @@ Define a `TokenBalance` entity type with a required one-to-many relationship wit
 
 ```graphql
 type Token @entity {
-  id: ID!
+  id: Bytes!
 }
 
 type TokenBalance @entity {
-  id: ID!
+  id: Bytes!
   amount: Int!
   token: Token!
 }
@@ -294,12 +295,12 @@ We can make the balances for a token accessible from the token by deriving a `to
 
 ```graphql
 type Token @entity {
-  id: ID!
+  id: Bytes!
   tokenBalances: [TokenBalance!]! @derivedFrom(field: "token")
 }
 
 type TokenBalance @entity {
-  id: ID!
+  id: Bytes!
   amount: Int!
   token: Token!
 }
@@ -315,13 +316,13 @@ Define a reverse lookup from a `User` entity type to an `Organization` entity ty
 
 ```graphql
 type Organization @entity {
-  id: ID!
+  id: Bytes!
   name: String!
   members: [User!]!
 }
 
 type User @entity {
-  id: ID!
+  id: Bytes!
   name: String!
   organizations: [Organization!]! @derivedFrom(field: "members")
 }
@@ -331,19 +332,19 @@ A more performant way to store this relationship is through a mapping table that
 
 ```graphql
 type Organization @entity {
-  id: ID!
+  id: Bytes!
   name: String!
   members: [UserOrganization]! @derivedFrom(field: "organization")
 }
 
 type User @entity {
-  id: ID!
+  id: Bytes!
   name: String!
   organizations: [UserOrganization!] @derivedFrom(field: "user")
 }
 
 type UserOrganization @entity {
-  id: ID! # Set to `${user.id}-${organization.id}`
+  id: Bytes! # Set to `user.id.concat(organization.id)`
   user: User!
   organization: Organization!
 }
@@ -373,7 +374,7 @@ As per GraphQL spec, comments can be added above schema entity attributes using 
 ```graphql
 type MyFirstEntity @entity {
   "unique identifier and primary key of the entity"
-  id: ID!
+  id: Bytes!
   address: Bytes!
 }
 ```
@@ -396,7 +397,7 @@ type _Schema_
   )
 
 type Band @entity {
-  id: ID!
+  id: Bytes!
   name: String!
   description: String!
   bio: String
@@ -469,7 +470,7 @@ import { NewGravatar, UpdatedGravatar } from '../generated/Gravity/Gravity'
 import { Gravatar } from '../generated/schema'
 
 export function handleNewGravatar(event: NewGravatar): void {
-  let gravatar = new Gravatar(event.params.id.toHex())
+  let gravatar = new Gravatar(event.params.id)
   gravatar.owner = event.params.owner
   gravatar.displayName = event.params.displayName
   gravatar.imageUrl = event.params.imageUrl
@@ -477,7 +478,7 @@ export function handleNewGravatar(event: NewGravatar): void {
 }
 
 export function handleUpdatedGravatar(event: UpdatedGravatar): void {
-  let id = event.params.id.toHex()
+  let id = event.params.id
   let gravatar = Gravatar.load(id)
   if (gravatar == null) {
     gravatar = new Gravatar(id)
@@ -735,7 +736,7 @@ import { CreateGravatarCall } from '../generated/Gravity/Gravity'
 import { Transaction } from '../generated/schema'
 
 export function handleCreateGravatar(call: CreateGravatarCall): void {
-  let id = call.transaction.hash.toHex()
+  let id = call.transaction.hash
   let transaction = new Transaction(id)
   transaction.displayName = call.inputs._displayName
   transaction.imageUrl = call.inputs._imageUrl
@@ -793,7 +794,7 @@ The mapping function will receive an `ethereum.Block` as its only argument. Like
 import { ethereum } from '@graphprotocol/graph-ts'
 
 export function handleBlock(block: ethereum.Block): void {
-  let id = block.hash.toHex()
+  let id = block.hash
   let entity = new Block(id)
   entity.save()
 }
@@ -884,7 +885,7 @@ If the subgraph encounters an error that query will return both the data and a g
 "data": {
     "foos": [
         {
-          "id": "fooId"
+          "id": "0xdead"
         }
     ],
     "_meta": {


### PR DESCRIPTION
* remove all mentions of the `ID` type from the docs and urge users to use `id: Bytes`
* explain the `@entity(immutable: true)` annotation