### PR TITLE
Corrected entry name for blockHandlers

### DIFF
--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -111,8 +111,8 @@ dataSources:
         - function: createGravatar(string,string)
           handler: handleCreateGravatar
       blockHandlers:
-        - function: handleBlock
-        - function: handleBlockWithCall
+        - handler: handleBlock
+        - handler: handleBlockWithCall
           filter:
             kind: call
       file: ./src/mapping.ts


### PR DESCRIPTION
blockHandlers do not have function entry, but only handler