### PR TITLE
Update matchstick docs demo subgraph url

### DIFF
--- a/pages/en/developer/matchstick.mdx
+++ b/pages/en/developer/matchstick.mdx
@@ -57,9 +57,9 @@ testsFolder: ./folderName
 libsFolder: path/to/libs
 ```
 
-### Example Subgraph
+### Demo subgraph
 
-You can try out and play around with the examples from this guide by cloning the [Example Subgraph repo](https://github.com/graphprotocol/example-subgraph)
+You can try out and play around with the examples from this guide by cloning the [Demo Subgraph repo](https://github.com/LimeChain/demo-subgraph)
 
 ### Video tutorials
 
@@ -67,7 +67,7 @@ Also you can check out the video series on ["How to use Matchstick to write unit
 
 ## Write a Unit Test
 
-Let's see how a simple unit test would look like, using the Gravatar [Example Subgraph](https://github.com/graphprotocol/example-subgraph).
+Let's see how a simple unit test would look like using the Gravatar examples in the [Demo Subgraph](https://github.com/LimeChain/demo-subgraph/blob/main/src/gravity.ts).
 
 Assuming we have the following handler function (along with two helper functions to make our life easier):
 


### PR DESCRIPTION
Matchstick docs changes:

- Changes section name from `Example Subgraph` to `Demo subgraph`
- Changes the url to `https://github.com/LimeChain/demo-subgraph` where the test examples are