### PR TITLE
fix broken link/created-subgraph-hosted.mdx

### DIFF
--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -553,7 +553,7 @@ A common pattern in Ethereum smart contracts is the use of registry or factory c
 
 ### Data Source for the Main Contract
 
-First, you define a regular data source for the main contract. The snippet below shows a simplified example data source for the [Uniswap](https://uniswap.io) exchange factory contract. Note the `NewExchange(address,address)` event handler. This is emitted when a new exchange contract is created on-chain by the factory contract.
+First, you define a regular data source for the main contract. The snippet below shows a simplified example data source for the [Uniswap](https://uniswap.org) exchange factory contract. Note the `NewExchange(address,address)` event handler. This is emitted when a new exchange contract is created on-chain by the factory contract.
 
 ```yaml
 dataSources:


### PR DESCRIPTION
404 error for uniswap. Updated to correct link on https://thegraph.com/docs/en/developer/create-subgraph-hosted/