### PR TITLE
Make the current page’s “group” (if there is one) accessible to Algolia’s Crawler

### DIFF
--- a/layout/NavContext.ts
+++ b/layout/NavContext.ts
@@ -1,14 +1,14 @@
 import { createContext, Context } from 'react'
 
-import { NavItem, NavItemPage } from '@/navigation'
+import { NavItem, NavItemPage, NavItemGroup } from '@/navigation'
 
 export type NavContextProps = {
   pagePath: string
   navItems: NavItem[]
-  pageNavItems: NavItemPage[]
   previousPage: NavItemPage | null
   currentPage: NavItemPage | null
   nextPage: NavItemPage | null
+  currentGroup: NavItemGroup | null
 }
 
 export const NavContext = createContext(null) as Context<NavContextProps | null>


### PR DESCRIPTION
This is so we can use that value as the [`lvl0`](https://docsearch.algolia.com/docs/record-extractor#lvl0), so pages that are nested in a group like "Developer" show up in a separate category in the search results.