### PR TITLE
Prevent Crowdin from reverting translated content to English

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,7 +4,9 @@ files:
     translation: /pages/%two_letters_code%/**/%original_file_name%
     dest: /**/%original_file_name%
     content_segmentation: 0
+    skip_untranslated_files: true
   - source: /pages/en/**/*.json
     translation: /pages/%two_letters_code%/**/%original_file_name%
     dest: /**/%original_file_name%
     content_segmentation: 0
+    skip_untranslated_strings: true


### PR DESCRIPTION
When Crowdin picks up _any change_ to a source (English) string (e.g. fixing a typo), it deletes all the translations for that string. That in itself is alright, because that's how translators know that they should at least review this string again (in case the change needs to be reflected in the translation), and the "Translation Memory" feature allows them to quickly retrieve the previous translation and either update it or reinstate it as is. The problem is that until they do that, Crowdin will push updates to the translated versions of the source file that was changed, reverting the string in question – properly translated and all – to the English one (of course, since the translation "no longer exists"... it does in the TM database, but that's Different™️). As a result, many pages in languages other than English are intertwined with English content, which doesn't result in a great user experience. Turns out Crowdin has a setting to _not_ push updates to files that are not 100% translated (`skip_untranslated_files: true`). It even has a setting to skip untranslated _strings_ (rather than _files_), but that one only works for structured content like JSON, not text-based files like Markdown. So, trying both of these settings out (first one for `.mdx` files, second one for `.json` files). As a result, there should be a higher chance that the content on a given non-English page is not 100% up-to-date with the English version, but it should always be in the right language at least!

 Let's see how it affects the next Crowdin PR.