### PR TITLE
Update subgraph features section with a new feature alias

### DIFF
--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -835,12 +835,12 @@ Inside the handler function, the receipt can be accessed in the `Event.receipt` 
 
 Starting from `specVersion` `0.0.4`, subgraph features must be explicitly declared in the `features` section at the top level of the manifest file, using their `camelCase` name, as listed in the table below:
 
-| Feature                                                   | Name                      |
-| --------------------------------------------------------- | ------------------------- |
-| [Non-fatal errors](#non-fatal-errors)                     | `nonFatalErrors`          |
-| [Full-text Search](#defining-fulltext-search-fields)      | `fullTextSearch`          |
-| [Grafting](#grafting-onto-existing-subgraphs)             | `grafting`                |
-| [IPFS on Ethereum Contracts](#ipfs-on-ethereum-contracts) | `ipfsOnEthereumContracts` |
+| Feature                                                   | Name                                                |
+| --------------------------------------------------------- | --------------------------------------------------- |
+| [Non-fatal errors](#non-fatal-errors)                     | `nonFatalErrors`                                    |
+| [Full-text Search](#defining-fulltext-search-fields)      | `fullTextSearch`                                    |
+| [Grafting](#grafting-onto-existing-subgraphs)             | `grafting`                                          |
+| [IPFS on Ethereum Contracts](#ipfs-on-ethereum-contracts) | `ipfsOnEthereumContracts` or `nonDeterministicIpfs` |
 
 For instance, if a subgraph uses the **Full-Text Search** and the **Non-fatal Errors** features, the `features` field in the manifest should be:
 
@@ -865,7 +865,7 @@ Given such IPFS hashes, subgraphs can read the corresponding files from IPFS usi
 
 In order to make this easy for subgraph developers, The Graph team wrote a tool for transferring files from one IPFS node to another, called [ipfs-sync](https://github.com/graphprotocol/ipfs-sync).
 
-> **[Feature Management](#experimental-features):** `ipfsOnEthereumContracts` must be declared under `features` in the subgraph manifest.
+> **[Feature Management](#experimental-features):** `ipfsOnEthereumContracts` must be declared under `features` in the subgraph manifest. For non EVM chains, the `nonDeterministicIpfs` alias can also be used for the same purpose.
 
 When running a local Graph Node, the `GRAPH_ALLOW_NON_DETERMINISTIC_IPFS` environment variable must be set in order to index subgraphs using this experimental functionality.
 


### PR DESCRIPTION
We've recently enabled subgraph `features` for non-EVM networks and the `ipfsOnEthereumcontracts` feature received an alias (`nonDeterministicIpfs`) to avoid incoherence between feature and network names.

This PR documents that alias.

Related PRs:
- https://github.com/graphprotocol/graph-cli/pull/889
- https://github.com/graphprotocol/graph-node/pull/3544