### PR TITLE
Warn about BigDecimal limitations

### DIFF
--- a/pages/en/developer/assemblyscript-api.mdx
+++ b/pages/en/developer/assemblyscript-api.mdx
@@ -93,6 +93,8 @@ import { BigDecimal } from '@graphprotocol/graph-ts'
 
 `BigDecimal` is used to represent arbitrary precision decimals.
 
+> Note: [Internally](https://github.com/graphprotocol/graph-node/blob/master/graph/src/data/store/scalar.rs) `BigDecimal` is stored in [IEEE-754 decimal128 floating-point format](https://en.wikipedia.org/wiki/Decimal128_floating-point_format), which supports 34 decimal digits of significand. This makes `BigDecimal` unsuitable for representing fixed-point types that can span wider than 34 digits, such as a Solidity [`ufixed256x18`](https://docs.soliditylang.org/en/latest/types.html#fixed-point-numbers) or equivalent.
+
 _Construction_
 
 - `constructor(bigInt: BigInt)` – creates a `BigDecimal` from an `BigInt`.


### PR DESCRIPTION
The documentation currently states that `BigDecimal` has arbitrary precision, but it does not.

For example, trying to represent the value `2 ** 256 - 1` in a `BigDecimal` as follows:
```as
const value = BigDecimal.fromString('115792089237316195423570985008687907853269984665640564039457584007913129639935');
```
will result in the following value being stored:
```
115792089237316195423570985008687900000000000000000000000000000000000000000000
```

Only the most significant 34 digits have been preserved, and it turns out that this is due to `BigDecimal`s [internally](https://github.com/graphprotocol/graph-node/blob/master/graph/src/data/store/scalar.rs) being stored in [IEEE-754 decimal128 floating-point format](https://en.wikipedia.org/wiki/Decimal128_floating-point_format), which supports 34 decimal digits of significand.

This makes `BigDecimal` unsuitable for representing fixed-point types that can span wider than 34 digits, such as a Solidity [`ufixed256x18`](https://docs.soliditylang.org/en/latest/types.html#fixed-point-numbers) or equivalent.

I think this could catch smart-contract developers unawares.

At first I was thinking of trying to fix, but after tracing the issue down to the Rust level, I decided to settle on a warning in the docs :slightly_smiling_face: