### PR TITLE
Fix command typo in `What is the Hosted Service` section

### DIFF
--- a/pages/ar/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ar/hosted-service/what-is-hosted-service.mdx
@@ -8,7 +8,7 @@ title: ما هي الخدمة المستضافة (Hosted Service)؟
 
 ## إنشاء الـ Subgraph
 
-اتبع أولاً التعليمات [ هنا ](/developer/define-subgraph-hosted) لتثبيت Graph CLI. قم بإنشاء subgraph عن طريق تمرير `graph init --product hosted service`
+اتبع أولاً التعليمات [ هنا ](/developer/define-subgraph-hosted) لتثبيت Graph CLI. قم بإنشاء subgraph عن طريق تمرير `graph init --product hosted-service`
 
 ### من عقد موجود
 

--- a/pages/en/hosted-service/what-is-hosted-service.mdx
+++ b/pages/en/hosted-service/what-is-hosted-service.mdx
@@ -8,7 +8,7 @@ If you don't have an account on the Hosted Service, you can signup with your Git
 
 ## Create a Subgraph
 
-First follow the instructions [here](/developer/define-subgraph-hosted) to install the Graph CLI. Create a subgraph by passing in `graph init --product hosted service`
+First follow the instructions [here](/developer/define-subgraph-hosted) to install the Graph CLI. Create a subgraph by passing in `graph init --product hosted-service`
 
 ### From an Existing Contract
 

--- a/pages/es/hosted-service/what-is-hosted-service.mdx
+++ b/pages/es/hosted-service/what-is-hosted-service.mdx
@@ -8,7 +8,7 @@ Si no tienes una cuenta en el Servicio Alojado, puedes registrarte con tu cuenta
 
 ## Crear un Subgrafo
 
-Primero sigue las instrucciones [aquí](/developer/define-subgraph-hosted) para instalar the Graph CLI. Crea un subgrafo pasando `graph init --product hosted service`
+Primero sigue las instrucciones [aquí](/developer/define-subgraph-hosted) para instalar the Graph CLI. Crea un subgrafo pasando `graph init --product hosted-service`
 
 ### De un Contrato Existente
 

--- a/pages/ja/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ja/hosted-service/what-is-hosted-service.mdx
@@ -8,7 +8,7 @@ title: ホステッドサービスとは？
 
 ## サブグラフの作成
 
-まず[こちら](/developer/define-subgraph-hosted)の指示に従って、Graph CLI をインストールします。`graph init --product hosted service`を渡してサブグラフを作成します。
+まず[こちら](/developer/define-subgraph-hosted)の指示に従って、Graph CLI をインストールします。`graph init --product hosted-service`を渡してサブグラフを作成します。
 
 ### 既存のコントラクトから
 

--- a/pages/ko/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ko/hosted-service/what-is-hosted-service.mdx
@@ -8,7 +8,7 @@ title: 호스팅 서비스란?
 
 ## 서브그래프 생성하기
 
-먼저 [여기](/developer/define-subgraph-hosted)의 지침에 따라 Graph CLI를 설치하십시오. `graph init --product hosted service`를 전달하여 서브그래프를 만듭니다.
+먼저 [여기](/developer/define-subgraph-hosted)의 지침에 따라 Graph CLI를 설치하십시오. `graph init --product hosted-service`를 전달하여 서브그래프를 만듭니다.
 
 ### 기존 컨트랙트로 부터
 

--- a/pages/vi/hosted-service/what-is-hosted-service.mdx
+++ b/pages/vi/hosted-service/what-is-hosted-service.mdx
@@ -8,7 +8,7 @@ If you don't have an account on the Hosted Service, you can signup with your Git
 
 ## Tạo một Subgraph
 
-First follow the instructions [here](/developer/define-subgraph-hosted) to install the Graph CLI. Create a subgraph by passing in `graph init --product hosted service`
+First follow the instructions [here](/developer/define-subgraph-hosted) to install the Graph CLI. Create a subgraph by passing in `graph init --product hosted-service`
 
 ### From an Existing Contract
 

--- a/pages/zh/hosted-service/what-is-hosted-service.mdx
+++ b/pages/zh/hosted-service/what-is-hosted-service.mdx
@@ -8,7 +8,7 @@ title: 什么是托管服务？
 
 ## 创建子图
 
-首先按照[此处](/developer/define-subgraph-hosted)的说明安装 Graph CLI。 通过传入 `graph init --product hosting service` 创建子图
+首先按照[此处](/developer/define-subgraph-hosted)的说明安装 Graph CLI。 通过传入 `graph init --product hosted-service` 创建子图
 
 ### 基于现有合约
 


### PR DESCRIPTION
I believe there is a typo in the `graph init` command under `Create a Subgraph`. Replaced all instances of `hosted/hosting service` with `hosted-service`

@graphprotocol/docs-reviewers