### PR TITLE
Adds moonbeam to hosted service

### DIFF
--- a/pages/ar/developer/developer-faq.mdx
+++ b/pages/ar/developer/developer-faq.mdx
@@ -128,6 +128,8 @@ curl -X POST -d '{ "query": "{indexingStatusForCurrentVersion(subgraphName: \"or
 - Celo-Alfajores
 - Fuse
 - Moonbeam
+- Moonriver
+- Moonbase Alpha (Moonbeam/Moonriver Testnet)
 - Arbitrum One
 - (Arbitrum Testnet (on Rinkeby
 - Optimism

--- a/pages/ar/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ar/hosted-service/what-is-hosted-service.mdx
@@ -67,8 +67,9 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo`
 - `celo-alfajores`
 - `fuse`
+- `moonbeam`
 - `moonriver`
-- `mbase`
+- `mbase` (Moonbeam/Moonriver TestNet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/ar/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ar/hosted-service/what-is-hosted-service.mdx
@@ -69,7 +69,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `fuse`
 - `moonbeam`
 - `moonriver`
-- `mbase` (Moonbeam/Moonriver TestNet)
+- `mbase` (Moonbeam/Moonriver Testnet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/en/developer/developer-faq.mdx
+++ b/pages/en/developer/developer-faq.mdx
@@ -128,6 +128,8 @@ In the Hosted Service, the following networks are supported:
 - Celo-Alfajores
 - Fuse
 - Moonbeam
+- Moonriver
+- Moonbase Alpha (Moonbeam/Moonriver Testnet)
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)
 - Optimism

--- a/pages/en/hosted-service/what-is-hosted-service.mdx
+++ b/pages/en/hosted-service/what-is-hosted-service.mdx
@@ -67,8 +67,9 @@ Please note that the following networks are supported on the Hosted Service. Net
 - `celo`
 - `celo-alfajores`
 - `fuse`
+- `moonbeam`
 - `moonriver`
-- `mbase`
+- `mbase` (Moonbeam/Moonriver TestNet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/en/hosted-service/what-is-hosted-service.mdx
+++ b/pages/en/hosted-service/what-is-hosted-service.mdx
@@ -69,7 +69,7 @@ Please note that the following networks are supported on the Hosted Service. Net
 - `fuse`
 - `moonbeam`
 - `moonriver`
-- `mbase` (Moonbeam/Moonriver TestNet)
+- `mbase` (Moonbeam/Moonriver Testnet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/es/developer/developer-faq.mdx
+++ b/pages/es/developer/developer-faq.mdx
@@ -128,6 +128,8 @@ En el Servicio Alojado, se admiten las siguientes redes:
 - Celo-Alfajores
 - Fuse
 - Moonbeam
+- Moonriver
+- Moonbase Alpha (Moonbeam/Moonriver Testnet)
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)
 - Optimism

--- a/pages/es/hosted-service/what-is-hosted-service.mdx
+++ b/pages/es/hosted-service/what-is-hosted-service.mdx
@@ -69,7 +69,7 @@ Ten en cuenta que las siguientes redes son admitidas en el Servicio Alojado. Las
 - `fuse`
 - `moonbeam`
 - `moonriver`
-- `mbase` (Moonbeam/Moonriver TestNet)
+- `mbase` (Moonbeam/Moonriver Testnet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/es/hosted-service/what-is-hosted-service.mdx
+++ b/pages/es/hosted-service/what-is-hosted-service.mdx
@@ -67,8 +67,9 @@ Ten en cuenta que las siguientes redes son admitidas en el Servicio Alojado. Las
 - `celo`
 - `celo-alfajores`
 - `fuse`
+- `moonbeam`
 - `moonriver`
-- `mbase`
+- `mbase` (Moonbeam/Moonriver TestNet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/ja/developer/developer-faq.mdx
+++ b/pages/ja/developer/developer-faq.mdx
@@ -128,6 +128,8 @@ curl -X POST -d '{ "query": "{indexingStatusForCurrentVersion(subgraphName: \"or
 - Celo-Alfajores
 - Fuse
 - Moonbeam
+- Moonriver
+- Moonbase Alpha (Moonbeam/Moonriver Testnet)
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)
 - Optimism

--- a/pages/ja/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ja/hosted-service/what-is-hosted-service.mdx
@@ -67,8 +67,9 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo`
 - `celo-alfajores`
 - `fuse`
+- `moonbeam`
 - `moonriver`
-- `mbase`
+- `mbase` (Moonbeam/Moonriver TestNet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/ja/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ja/hosted-service/what-is-hosted-service.mdx
@@ -69,7 +69,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `fuse`
 - `moonbeam`
 - `moonriver`
-- `mbase` (Moonbeam/Moonriver TestNet)
+- `mbase` (Moonbeam/Moonriver Testnet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/ko/developer/developer-faq.mdx
+++ b/pages/ko/developer/developer-faq.mdx
@@ -128,6 +128,8 @@ The Graph 노드는 모든 EVM 호환 JSON RPC API 체인을 지원합니다.
 - Celo-Alfajores
 - Fuse
 - Moonbeam
+- Moonriver
+- Moonbase Alpha (Moonbeam/Moonriver Testnet)
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)
 - Optimism

--- a/pages/ko/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ko/hosted-service/what-is-hosted-service.mdx
@@ -67,8 +67,9 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo`
 - `celo-alfajores`
 - `fuse`
+- `moonbeam`
 - `moonriver`
-- `mbase`
+- `mbase` (Moonbeam/Moonriver TestNet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/ko/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ko/hosted-service/what-is-hosted-service.mdx
@@ -69,7 +69,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `fuse`
 - `moonbeam`
 - `moonriver`
-- `mbase` (Moonbeam/Moonriver TestNet)
+- `mbase` (Moonbeam/Moonriver Testnet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/vi/developer/developer-faq.mdx
+++ b/pages/vi/developer/developer-faq.mdx
@@ -128,6 +128,8 @@ Trong Dịch vụ được lưu trữ, các mạng sau được hỗ trợ:
 - Celo-Alfajores
 - Fuse
 - Moonbeam
+- Moonriver
+- Moonbase Alpha (Moonbeam/Moonriver Testnet)
 - Arbitrum One
 - Arbitrum Testnet (trên Rinkeby)
 - Optimism

--- a/pages/vi/hosted-service/what-is-hosted-service.mdx
+++ b/pages/vi/hosted-service/what-is-hosted-service.mdx
@@ -67,8 +67,9 @@ Please note that the following networks are supported on the Hosted Service. Net
 - `celo`
 - `celo-alfajores`
 - `fuse`
+- `moonbeam`
 - `moonriver`
-- `mbase`
+- `mbase` (Moonbeam/Moonriver TestNet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/vi/hosted-service/what-is-hosted-service.mdx
+++ b/pages/vi/hosted-service/what-is-hosted-service.mdx
@@ -69,7 +69,7 @@ Please note that the following networks are supported on the Hosted Service. Net
 - `fuse`
 - `moonbeam`
 - `moonriver`
-- `mbase` (Moonbeam/Moonriver TestNet)
+- `mbase` (Moonbeam/Moonriver Testnet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/zh/developer/developer-faq.mdx
+++ b/pages/zh/developer/developer-faq.mdx
@@ -128,6 +128,8 @@ Graph Network 支持子图索引以太坊主网：
 - Celo-Alfajores
 - Fuse
 - Moonbeam
+- Moonriver
+- Moonbase Alpha (Moonbeam/Moonriver Testnet)
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)
 - Optimism

--- a/pages/zh/hosted-service/what-is-hosted-service.mdx
+++ b/pages/zh/hosted-service/what-is-hosted-service.mdx
@@ -67,8 +67,9 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo`
 - `celo-alfajores`
 - `fuse`
+- `moonbeam`
 - `moonriver`
-- `mbase`
+- `mbase` (Moonbeam/Moonriver TestNet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`

--- a/pages/zh/hosted-service/what-is-hosted-service.mdx
+++ b/pages/zh/hosted-service/what-is-hosted-service.mdx
@@ -69,7 +69,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `fuse`
 - `moonbeam`
 - `moonriver`
-- `mbase` (Moonbeam/Moonriver TestNet)
+- `mbase` (Moonbeam/Moonriver Testnet)
 - `arbitrum-one`
 - `arbitrum-rinkeby`
 - `optimism`


### PR DESCRIPTION
This PR adds Moonbeam to the hosted service page. Also clarifies that `mbase` is Moonbeam/Moonriver TestNet.
