### PR TITLE
Add Moonbeam/Moonriver to list of supported networks (docs)

### DIFF
--- a/pages/ar/developer/create-subgraph-hosted.mdx
+++ b/pages/ar/developer/create-subgraph-hosted.mdx
@@ -36,6 +36,7 @@ title: إنشاء الـ Subgraph
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/ar/developer/developer-faq.mdx
+++ b/pages/ar/developer/developer-faq.mdx
@@ -127,6 +127,7 @@ curl -X POST -d '{ "query": "{indexingStatusForCurrentVersion(subgraphName: \"or
 - Celo
 - Celo-Alfajores
 - Fuse
+- Moonriver
 - Moonbeam
 - Arbitrum One
 - (Arbitrum Testnet (on Rinkeby

--- a/pages/ar/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ar/hosted-service/what-is-hosted-service.mdx
@@ -68,6 +68,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/en/developer/create-subgraph-hosted.mdx
+++ b/pages/en/developer/create-subgraph-hosted.mdx
@@ -36,6 +36,7 @@ The Graph Network supports subgraphs indexing mainnet Ethereum:
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/en/developer/developer-faq.mdx
+++ b/pages/en/developer/developer-faq.mdx
@@ -127,6 +127,7 @@ In the Hosted Service, the following networks are supported:
 - Celo
 - Celo-Alfajores
 - Fuse
+- Moonriver
 - Moonbeam
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)

--- a/pages/en/hosted-service/what-is-hosted-service.mdx
+++ b/pages/en/hosted-service/what-is-hosted-service.mdx
@@ -68,6 +68,7 @@ Please note that the following networks are supported on the Hosted Service. Net
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/es/developer/create-subgraph-hosted.mdx
+++ b/pages/es/developer/create-subgraph-hosted.mdx
@@ -36,6 +36,7 @@ The Graph Network admite subgrafos que indexan la red principal de Ethereum:
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/es/developer/developer-faq.mdx
+++ b/pages/es/developer/developer-faq.mdx
@@ -127,6 +127,7 @@ En el Servicio Alojado, se admiten las siguientes redes:
 - Celo
 - Celo-Alfajores
 - Fuse
+- Moonriver
 - Moonbeam
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)

--- a/pages/es/hosted-service/what-is-hosted-service.mdx
+++ b/pages/es/hosted-service/what-is-hosted-service.mdx
@@ -68,6 +68,7 @@ Ten en cuenta que las siguientes redes son admitidas en el Servicio Alojado. Las
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/ja/developer/create-subgraph-hosted.mdx
+++ b/pages/ja/developer/create-subgraph-hosted.mdx
@@ -36,6 +36,7 @@ The Graph Network は、メインネットの Ethereum をインデックスと�
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/ja/developer/developer-faq.mdx
+++ b/pages/ja/developer/developer-faq.mdx
@@ -127,6 +127,7 @@ curl -X POST -d '{ "query": "{indexingStatusForCurrentVersion(subgraphName: \"or
 - Celo
 - Celo-Alfajores
 - Fuse
+- Moonriver
 - Moonbeam
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)

--- a/pages/ja/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ja/hosted-service/what-is-hosted-service.mdx
@@ -68,6 +68,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/ko/developer/create-subgraph-hosted.mdx
+++ b/pages/ko/developer/create-subgraph-hosted.mdx
@@ -36,6 +36,7 @@ Graph CLI를 사용하기 전에, 여러분은 [Subgraph Studio](https://thegrap
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/ko/developer/developer-faq.mdx
+++ b/pages/ko/developer/developer-faq.mdx
@@ -127,6 +127,7 @@ The Graph 노드는 모든 EVM 호환 JSON RPC API 체인을 지원합니다.
 - Celo
 - Celo-Alfajores
 - Fuse
+- Moonriver
 - Moonbeam
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)

--- a/pages/ko/hosted-service/what-is-hosted-service.mdx
+++ b/pages/ko/hosted-service/what-is-hosted-service.mdx
@@ -68,6 +68,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/vi/developer/create-subgraph-hosted.mdx
+++ b/pages/vi/developer/create-subgraph-hosted.mdx
@@ -36,6 +36,7 @@ Mạng The Graph hỗ trợ lập chỉ mục các subgraph mạng chính Ethere
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/vi/developer/developer-faq.mdx
+++ b/pages/vi/developer/developer-faq.mdx
@@ -127,6 +127,7 @@ Trong Dịch vụ được lưu trữ, các mạng sau được hỗ trợ:
 - Celo
 - Celo-Alfajores
 - Fuse
+- Moonriver
 - Moonbeam
 - Arbitrum One
 - Arbitrum Testnet (trên Rinkeby)

--- a/pages/vi/hosted-service/what-is-hosted-service.mdx
+++ b/pages/vi/hosted-service/what-is-hosted-service.mdx
@@ -68,6 +68,7 @@ Please note that the following networks are supported on the Hosted Service. Net
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/zh/developer/create-subgraph-hosted.mdx
+++ b/pages/zh/developer/create-subgraph-hosted.mdx
@@ -36,6 +36,7 @@ Graph Network 支持子图索引以太坊主网：
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`

--- a/pages/zh/developer/developer-faq.mdx
+++ b/pages/zh/developer/developer-faq.mdx
@@ -127,6 +127,7 @@ Graph Network 支持子图索引以太坊主网：
 - Celo
 - Celo-Alfajores
 - Fuse
+- Moonriver
 - Moonbeam
 - Arbitrum One
 - Arbitrum Testnet (on Rinkeby)

--- a/pages/zh/hosted-service/what-is-hosted-service.mdx
+++ b/pages/zh/hosted-service/what-is-hosted-service.mdx
@@ -68,6 +68,7 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 - `celo-alfajores`
 - `fuse`
 - `moonriver`
+- `moonbeam`
 - `mbase`
 - `arbitrum-one`
 - `arbitrum-rinkeby`


### PR DESCRIPTION
- It seems like the docs were never updated from when `moonbeam` was added to the list of networks supported on the Hosted Service.

- Also, `Moonriver` was missing from the list of supported networks in the developer FAQs.

This fixes that in every language.