### PR TITLE
Sunsetting hosted service & ReadMe clone command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is built on [Next.js](https://nextjs.org/). You can run it on your 
 First, clone the repo:
 
 ```bash
-git clone git@github.com:graphprotocol/docs.git
+git clone https://github.com/graphprotocol/docs.git
 ```
 
 Make sure you are inside the folder:

--- a/pages/en/deploying/hosted-service.mdx
+++ b/pages/en/deploying/hosted-service.mdx
@@ -2,6 +2,8 @@
 title: What is the Hosted Service?
 ---
 
+> Please note, the Hosted Service is sunsetting in Q1 2023, but it will remain available until that time. All developers are strongly encouraged to [migrate their subgraphs](https://thegraph.com/blog/how-to-migrate-ethereum-subgraph) to the decentralized network. Read more about the sunsetting of the Hosted Service [here](https://thegraph.com/blog/sunsetting-hosted-service).
+
 This section will walk you through deploying a subgraph to the Hosted Service, otherwise known as the [Hosted Service.](https://thegraph.com/hosted-service/) As a reminder, the Hosted Service will not be shut down soon. We will gradually sunset the Hosted Service once we reach feature parity with the decentralized network. Your subgraphs deployed on the Hosted Service are still available [here.](https://thegraph.com/hosted-service/)
 
 If you don't have an account on the Hosted Service, you can signup with your Github account. Once you authenticate, you can start creating subgraphs through the UI and deploying them from your terminal. Graph Node supports a number of Ethereum testnets (Rinkeby, Ropsten, Kovan) in addition to mainnet.


### PR DESCRIPTION
Added message about deprecated hosting service & fixed the command to copy the repo on ReadMe - previous command did not work.