### PR TITLE
Updating anonymous event signature

### DIFF
--- a/pages/en/developing/creating-a-subgraph.mdx
+++ b/pages/en/developing/creating-a-subgraph.mdx
@@ -820,7 +820,7 @@ If you need to process anonymous events in Solidity, that can be achieved by pro
 ```yaml
 eventHandlers:
   - event: LogNote(bytes4,address,bytes32,bytes32,uint256,bytes)
-    topic0: '0xbaa8529c00000000000000000000000000000000000000000000000000000000'
+    topic0: '0x644843f351d3fba4abcd60109eaff9f54bac8fb8ccf0bab941009c21df21cf31'
     handler: handleGive
 ```
 


### PR DESCRIPTION
The topic0 on the anonymous event does not properly reflect the keccak256 hash of the event signature.

Correct hash: 0x644843f351d3fba4abcd60109eaff9f54bac8fb8ccf0bab941009c21df21cf31
https://bfotool.com/keccak256-hash-generator