### PR TITLE
doc(querying): replace code examples with graph-client

### DIFF
--- a/navigation/navigation.ts
+++ b/navigation/navigation.ts
@@ -115,10 +115,10 @@ export const navigation = (locale: AppLocale): NavItemDefinition[] => [
         slug: 'managing-api-keys',
       },
       {
-        slug: 'querying-from-an-application',
+        slug: 'querying-best-practices',
       },
       {
-        slug: 'querying-best-practices',
+        slug: 'querying-from-an-application',
       },
       {
         slug: 'distributed-systems',

--- a/pages/en/querying/querying-best-practices.mdx
+++ b/pages/en/querying/querying-best-practices.mdx
@@ -71,9 +71,21 @@ For a complete list of rules with code examples, please look at our GraphQL Vali
 
 GraphQL is a language and set of conventions that transport over HTTP.
 
-It means that you can query a GraphQL API using standard `fetch` (natively or via `cross-undici-fetch` or `isomorphic-fetch`) as follows:
+It means that you can query a GraphQL API using standard `fetch` (natively or via `@whatwg-node/fetch` or `isomorphic-fetch`).
+
+However, as stated in ["Querying from an Application"](/querying/querying-from-an-application) we recommend you to use our `graph-client` that support unique features such as:
+- Cross-chain Subgraph Handling: Querying from multiple subgraphs in a single query
+- [Automatic Block Tracking](https://github.com/graphprotocol/graph-client/blob/main/packages/block-tracking/README.md)
+- [Automatic Pagination](https://github.com/graphprotocol/graph-client/blob/main/packages/auto-pagination/README.md)
+- Fully typed result
+
+<br />
+
+Here's how to query The Graph with `graph-client`:
 
 ```tsx
+import { execute } from '../.graphclient'
+
 const query = `
 query GetToken($id: ID!) {
   token(id: $id) {
@@ -84,55 +96,16 @@ query GetToken($id: ID!) {
 `
 const variables = { id: '1' }
 
-const fetchResult = await fetch('http://example.com/graphql', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ query, variables }),
-})
-const result = await fetchResult.json()
+async function main() {
+  const result = await execute(query, variables)
+  // `result` is fully typed!
+  console.log(result)
+}
+
+main()
 ```
 
-Another lightweight alternative, best for back-end use-cases, is the famous [`graphql-request` library](https://github.com/prisma-labs/graphql-request).
-
-This lightweight GraphQL client comes with the essential features to query a GraphQL API:
-
-- Mutations validation
-- Support for file upload
-- Batching
-- Promise-based API
-- TypeScript support
-
-<br />
-
-A complete GraphQL client is [URQL](https://formidable.com/open-source/urql/) which is available within Node.js, React/Preact, Vue, Svelte environments, with more advanced features:
-
-- Flexible cache system
-- Extensible design (easing adding new capabilities on top of it)
-- Lightweight bundle (~5x lighter than Apollo Client)
-- Support for file uploads and offline mode
-
-<br />
-
-In the React ecosystem, [React Query](https://react-query.tanstack.com/graphql) brings a lightweight and agnostic solution for GraphQL.
-
-React Query is a great candidate if you are looking for an easy-to-use and lightweight multipurpose client (GraphQL-capable) that provides essential features such as:
-
-- Powerful cache (background refresh, window-focus refreshing)
-- Advanced querying pattern (parallel queries, dependent queries, prefetching)
-- UX patterns: optimistic updates, scroll restoration
-- Great dev tools
-
-<br />
-
-Finally, Apollo Client is the ubiquitous GraphQL client on the front-end ecosystem.
-
-Available for React, Angular, Vue, Ember, iOS, and Android, Apollo Client, although the heaviest clients, brings many features to build advanced UI on-top of GraphQL:
-
-- advanced error handling
-- pagination
-- data prefetching
-- optimistic UI
-- local state management
+More GraphQL clients alternatives are covered in ["Querying from an Application"](/querying/querying-from-an-application).
 
 <br />
 
@@ -503,69 +476,3 @@ The [JS GraphQL plugin](https://plugins.jetbrains.com/plugin/8097-graphql/) will
 - snippets
 
 More information on this [WebStorm article](https://blog.jetbrains.com/webstorm/2019/04/featured-plugin-js-graphql/) that showcases all the plugin's main features.
-
-<br />
-
-### TypeScript types generation
-
-Finally, the best GraphQL experience is reached when the TypeScript data types are generated from the defined GraphQL queries, as follows:
-
-```tsx
-import { execute } from 'your-favorite-graphql-client'
-import { GetTokenQuery } from './generated.'
-
-const id = params.id
-const query = `
-query GetToken($id: ID!) {
-  token(id: $id) {
-    id
-    owner
-  }
-}
-`
-
-const result: GetTokenQuery = await execute(query, {
-  variables: {
-    id,
-  },
-})
-
-// `result` is typed!
-```
-
-Such a setup can be easily achieved by installing and configuring [GraphQL Code Generator](https://www.graphql-code-generator.com/docs/getting-started) as follows:
-
-```bash
-yarn add graphql @graphql-codegen/cli @graphql-codegen/typescript @graphql-codegen/typescript-operations
-```
-
-Then update your `package.json` (or similar script configuration setup) as follows:
-
-```tsx
-{
-  // ...
-  "scripts": {
-    // ...
-    "generate": "graphql-codegen",
-    // ...
-  }
-  // ...
-}
-```
-
-Add the following configuration file to your project:
-
-```tsx
-schema: "<SUBGRAPH_URL>"
-documents: './src/**/*.ts'
-generates:
-  ./generated.ts:
-    plugins:
-      - typescript
-      - typescript-operations
-```
-
-Finally, by simply running the configured script (`yarn generate`), GraphQL Code Generator will generate the proper TypeScript types in the `generated.ts` file:
-
-- Each query will get a corresponding `[QueryName]Query` type (ex: `GetToken` → `GetTokenQuery` type
-- Each fragment will get a corresponding `[FragmentName]Fragment` type (ex: `DelegateItem` → `DelegateItemFragment` type

--- a/pages/en/querying/querying-best-practices.mdx
+++ b/pages/en/querying/querying-best-practices.mdx
@@ -73,7 +73,7 @@ GraphQL is a language and set of conventions that transport over HTTP.
 
 It means that you can query a GraphQL API using standard `fetch` (natively or via `@whatwg-node/fetch` or `isomorphic-fetch`).
 
-However, as stated in ["Querying from an Application"](/querying/querying-from-an-application) we recommend you to use our `graph-client` that support unique features such as:
+However, as stated in ["Querying from an Application"](/querying/querying-from-an-application), we recommend you to use our `graph-client` that supports unique features such as:
 - Cross-chain Subgraph Handling: Querying from multiple subgraphs in a single query
 - [Automatic Block Tracking](https://github.com/graphprotocol/graph-client/blob/main/packages/block-tracking/README.md)
 - [Automatic Pagination](https://github.com/graphprotocol/graph-client/blob/main/packages/auto-pagination/README.md)
@@ -105,7 +105,7 @@ async function main() {
 main()
 ```
 
-More GraphQL clients alternatives are covered in ["Querying from an Application"](/querying/querying-from-an-application).
+More GraphQL client alternatives are covered in ["Querying from an Application"](/querying/querying-from-an-application).
 
 <br />
 

--- a/pages/en/querying/querying-from-an-application.mdx
+++ b/pages/en/querying/querying-from-an-application.mdx
@@ -27,7 +27,7 @@ Here are a couple of the more popular GraphQL clients in the ecosystem and how t
 
 ### Graph client
 
-The Graph is providing it own GraphQL client, `graph-client` that support unique features such as:
+The Graph is providing it own GraphQL client, `graph-client` that supports unique features such as:
 - Cross-chain Subgraph Handling: Querying from multiple subgraphs in a single query
 - [Automatic Block Tracking](https://github.com/graphprotocol/graph-client/blob/main/packages/block-tracking/README.md)
 - [Automatic Pagination](https://github.com/graphprotocol/graph-client/blob/main/packages/auto-pagination/README.md)
@@ -143,9 +143,9 @@ export default App
 
 **⚠️ Important notice**
 
-`graph-client` is perfectly integrated with other GraphQL clients such as Apollo client, URQL or React Query, you will [find examples in the official repository](https://github.com/graphprotocol/graph-client/tree/main/examples).
+`graph-client` is perfectly integrated with other GraphQL clients such as Apollo client, URQL, or React Query; you will [find examples in the official repository](https://github.com/graphprotocol/graph-client/tree/main/examples).
 
-However, if you choose to go with another client, keep in mind that **you won't be able to get to use Cross-chain Subgraph Handling or Automatic Pagination which are core features for querying The Graph**.
+However, if you choose to go with another client, keep in mind that **you won't be able to get to use Cross-chain Subgraph Handling or Automatic Pagination, which are core features for querying The Graph**.
 
 <br />
 
@@ -239,7 +239,7 @@ client
 
 ### URQL
 
-Another option is [URQL](https://formidable.com/open-source/urql/) which is available within Node.js, React/Preact, Vue, Svelte environments, with more advanced features:
+Another option is [URQL](https://formidable.com/open-source/urql/) which is available within Node.js, React/Preact, Vue, and Svelte environments, with more advanced features:
 
 - Flexible cache system
 - Extensible design (easing adding new capabilities on top of it)

--- a/pages/en/querying/querying-from-an-application.mdx
+++ b/pages/en/querying/querying-from-an-application.mdx
@@ -22,9 +22,146 @@ Using the GraphQL endpoint, you can use various GraphQL Client libraries to quer
 
 Here are a couple of the more popular GraphQL clients in the ecosystem and how to use them:
 
+## GraphQL clients
+
+
+### Graph client
+
+The Graph is providing it own GraphQL client, `graph-client` that support unique features such as:
+- Cross-chain Subgraph Handling: Querying from multiple subgraphs in a single query
+- [Automatic Block Tracking](https://github.com/graphprotocol/graph-client/blob/main/packages/block-tracking/README.md)
+- [Automatic Pagination](https://github.com/graphprotocol/graph-client/blob/main/packages/auto-pagination/README.md)
+- Fully typed result
+
+<br />
+
+Also integrated with popular GraphQL clients such as Apollo and URQL and compatible with all environments (React, Angular, Node.js, React Native), using `graph-client` will give you the best experience for interacting with The Graph.
+
+<br />
+
+Let's look at how to fetch data from a subgraph with `graphql-client`.
+
+To get started, make sure to install The Graph Client CLI in your project:
+
+```sh
+yarn add -D @graphprotocol/client-cli
+# or, with NPM:
+npm install --save-dev @graphprotocol/client-cli
+```
+
+Define you query in a `.graphql` file (or inlined in your `.js` or `.ts` file):
+
+```graphql
+query ExampleQuery {
+  # this one is coming from compound-v2
+  markets(first: 7) {
+    borrowRate
+    cash
+    collateralFactor
+  }
+  # this one is coming from uniswap-v2
+  pair(id: "0x00004ee988665cdda9a1080d5792cecd16dc1220") {
+    id
+    token0 {
+      id
+      symbol
+      name
+    }
+    token1 {
+      id
+      symbol
+      name
+    }
+  }
+}
+```
+
+
+Then, create a configuration file (called `.graphclientrc.yml`) and point to your GraphQL endpoints provided by The Graph, for example:
+
+```yaml
+# .graphclientrc.yml
+sources:
+  - name: uniswapv2
+    handler:
+      graphql:
+        endpoint: https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2
+  - name: compoundv2
+    handler:
+      graphql:
+        endpoint: https://api.thegraph.com/subgraphs/name/graphprotocol/compound-v2
+
+documents:
+  - ./src/example-query.graphql
+```
+
+Running the following The Graph Client CLI command will generate typed and ready to use JavaScript code:
+
+```sh
+graphclient build
+```
+
+Finally, update your `.ts` file to use the generated typed GraphQL documents:
+
+```tsx
+import React, { useEffect } from 'react'
+// ...
+// we import types and typed-graphql document from the generated code (`..graphclient/`)
+import { ExampleQueryDocument, ExampleQueryQuery, execute } from '../.graphclient'
+
+function App() {
+  const [data, setData] = React.useState<ExampleQueryQuery>()
+
+  useEffect(() => {
+    execute(ExampleQueryDocument, {}).then((result) => {
+      setResult(result?.data)
+    })
+  }, [])
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        <p>Graph Client Example</p>
+        <fieldset>
+          {data && (
+            <form>
+              <label>Data</label>
+              <br />
+              <textarea value={JSON.stringify(result.data, null, 2)} readOnly rows={25} />
+            </form>
+          )}
+        </fieldset>
+      </header>
+    </div>
+  )
+}
+
+export default App
+```
+
+<br />
+
+**⚠️ Important notice**
+
+`graph-client` is perfectly integrated with other GraphQL clients such as Apollo client, URQL or React Query, you will [find examples in the official repository](https://github.com/graphprotocol/graph-client/tree/main/examples).
+
+However, if you choose to go with another client, keep in mind that **you won't be able to get to use Cross-chain Subgraph Handling or Automatic Pagination which are core features for querying The Graph**.
+
+<br />
+
 ### Apollo client
 
-[Apollo client](https://www.apollographql.com/docs/) supports web projects, including frameworks like React and Vue, as well as mobile clients like iOS, Android, and React Native.
+[Apollo client](https://www.apollographql.com/docs/) is the ubiquitous GraphQL client on the front-end ecosystem.
+
+Available for React, Angular, Vue, Ember, iOS, and Android, Apollo Client, although the heaviest clients, brings many features to build advanced UI on-top of GraphQL:
+
+- advanced error handling
+- pagination
+- data prefetching
+- optimistic UI
+- local state management
+
+<br />
 
 Let's look at how to fetch data from a subgraph with Apollo client in a web project.
 
@@ -98,9 +235,18 @@ client
   })
 ```
 
+<br />
+
 ### URQL
 
-Another option is [URQL](https://formidable.com/open-source/urql/), a somewhat lighter-weight GraphQL client library.
+Another option is [URQL](https://formidable.com/open-source/urql/) which is available within Node.js, React/Preact, Vue, Svelte environments, with more advanced features:
+
+- Flexible cache system
+- Extensible design (easing adding new capabilities on top of it)
+- Lightweight bundle (~5x lighter than Apollo Client)
+- Support for file uploads and offline mode
+
+<br />
 
 Let's look at how to fetch data from a subgraph with URQL in a web project.
 

--- a/pages/en/querying/querying-from-an-application.mdx
+++ b/pages/en/querying/querying-from-an-application.mdx
@@ -153,7 +153,7 @@ However, if you choose to go with another client, keep in mind that **you won't 
 
 [Apollo client](https://www.apollographql.com/docs/) is the ubiquitous GraphQL client on the front-end ecosystem.
 
-Available for React, Angular, Vue, Ember, iOS, and Android, Apollo Client, although the heaviest clients, brings many features to build advanced UI on-top of GraphQL:
+Available for React, Angular, Vue, Ember, iOS, and Android, Apollo Client, although the heaviest client, brings many features to build advanced UI on top of GraphQL:
 
 - advanced error handling
 - pagination


### PR DESCRIPTION
@azf20, here are the changes to better showcase our [`graph-client`](https://github.com/graphprotocol/graph-client) in code examples ✨ 

I also changed the content navigation by moving "Querying Best Practices" above "Querying from an Application" because people need to know about GraphQL best practices before talking about client (IMHO)