### PR TITLE
Removed padding for left sidebar elements

### DIFF
--- a/components/NavTree.tsx
+++ b/components/NavTree.tsx
@@ -68,7 +68,7 @@ const NavTreeItem = ({
   const { sx: linkSx, ...linkOtherProps } = linkProps
   const { sx: diamondSx, ...diamondOtherProps } = diamondProps
   return (
-    <li sx={{ py: Spacing.M }} {...props}>
+    <li {...props}>
       <Link
         href={href}
         target={target}
@@ -127,7 +127,7 @@ const NavTreeGroupHeading = ({ children, buttonProps = {}, ...props }: NavTreeGr
   const { t } = useI18n()
 
   return (
-    <div sx={{ py: Spacing.M }} {...props}>
+    <div {...props}>
       <Collapsible.Trigger
         sx={{
           width: '100%',

--- a/components/NavTree.tsx
+++ b/components/NavTree.tsx
@@ -186,7 +186,7 @@ const NavTreeDivider = (props: NavTreeDividerProps) => {
 
 const NavTreeHeading = ({ children, ...props }: NavTreeHeadingProps) => {
   return (
-    <li sx={{ mt: Spacing.XL, mb: Spacing.M_L, paddingInlineStart: Spacing.L_XL }} {...props}>
+    <li sx={{ mt: Spacing.L_XL, mb: Spacing.M_L, paddingInlineStart: Spacing.L_XL }} {...props}>
       <Text.C12 color="White48">{children}</Text.C12>
     </li>
   )


### PR DESCRIPTION
This doesn't have a task, removed padding on the sidebar, and the dropdown elements padding so it doesn't look so big and takes so much space.


<img width="315" alt="Screenshot 2022-08-17 at 14 43 45" src="https://user-images.githubusercontent.com/31341867/185053536-f1034b10-49e9-4d7e-80c5-29c8f1c3f12c.png">
<img width="341" alt="Screenshot 2022-08-17 at 14 43 56" src="https://user-images.githubusercontent.com/31341867/185053559-72393e88-59cf-4089-9316-9b153b0c6258.png">
