### PR TITLE
Add ability to customize SEO title, image, etc. in MDX frontmatter

### DIFF
--- a/layout/DocumentContext.ts
+++ b/layout/DocumentContext.ts
@@ -1,8 +1,10 @@
+import { NextSeoProps } from 'next-seo'
 import { Context, createContext } from 'react'
 
 export type Frontmatter = {
   title?: string
   navTitle?: string
+  seo?: NextSeoProps
 }
 
 export type OutlineItem = {

--- a/layout/MDXLayout.tsx
+++ b/layout/MDXLayout.tsx
@@ -134,10 +134,14 @@ export const MDXLayout = ({ pagePath, navItems, frontmatter, outline, children }
     return _highlightedOutlineItemId
   }, [outline, outlineItemIsInOrAboveView])
 
+  const seo = { ...(frontmatter?.seo ?? {}) }
+  seo.title = seo.title ?? frontmatter?.title
+  seo.title = `${seo.title ? `${seo.title} - ` : ''}The Graph Docs`
+
   return (
     <NavContext.Provider value={{ pagePath, navItems, previousPage, currentPage, nextPage, currentGroup }}>
       <DocumentContext.Provider value={{ frontmatter, outline, markOutlineItem, highlightedOutlineItemId }}>
-        <NextSeo title={`${frontmatter?.title ? `${frontmatter.title} - ` : ''} The Graph Docs`} />
+        <NextSeo {...seo} />
 
         <div
           sx={{


### PR DESCRIPTION
Here's how this can be used in a page:

```mdx
---
title: Title that appears on the page and in the nav
seo:
  title: This is used for the `<title>` tag instead of the above `title`
  openGraph:
    images:
      - url: 'https://example.com/seo-image.jpg'
        alt: Optional alt text for the SEO image
---

Page content...
```