### PR TITLE
Removing recommendation against grafting

### DIFF
--- a/pages/ar/developing/creating-a-subgraph.mdx
+++ b/pages/ar/developing/creating-a-subgraph.mdx
@@ -904,8 +904,6 @@ If the subgraph encounters an error that query will return both the data and a g
 
 When a subgraph is first deployed, it starts indexing events at the genesis block of the corresponding chain (or at the `startBlock` defined with each data source) In some circumstances, it is beneficial to reuse the data from an existing subgraph and start indexing at a much later block. This mode of indexing is called _Grafting_. Grafting is, for example, useful during development to get past simple errors in the mappings quickly, or to temporarily get an existing subgraph working again after it has failed.
 
-> **ملاحظة:** الـ Grafting يتطلب أن المفهرس قد فهرس الـ subgraph الأساسي. لا يوصى باستخدامه على شبكة The Graph في الوقت الحالي ، ولا ينبغي للمطورين نشر الـ subgraphs على الشبكة باستخدام تلك الدالة عبر الـ Studio.
-
 A subgraph is grafted onto a base subgraph when the subgraph manifest in `subgraph.yaml` contains a `graft` block at the toplevel:
 
 ```yaml

--- a/pages/en/developing/creating-a-subgraph.mdx
+++ b/pages/en/developing/creating-a-subgraph.mdx
@@ -932,8 +932,6 @@ If the subgraph encounters an error, that query will return both the data and a 
 
 When a subgraph is first deployed, it starts indexing events at the genesis block of the corresponding chain (or at the `startBlock` defined with each data source) In some circumstances; it is beneficial to reuse the data from an existing subgraph and start indexing at a much later block. This mode of indexing is called _Grafting_. Grafting is, for example, useful during development to get past simple errors in the mappings quickly or to temporarily get an existing subgraph working again after it has failed.
 
-> **Note:** Grafting requires that the Indexer has indexed the base subgraph. It is not recommended on The Graph Network at this time, and developers should not deploy subgraphs using that functionality to the network via the Studio.
-
 A subgraph is grafted onto a base subgraph when the subgraph manifest in `subgraph.yaml` contains a `graft` block at the top-level:
 
 ```yaml

--- a/pages/es/developing/creating-a-subgraph.mdx
+++ b/pages/es/developing/creating-a-subgraph.mdx
@@ -904,8 +904,6 @@ If the subgraph encounters an error that query will return both the data and a g
 
 When a subgraph is first deployed, it starts indexing events at the genesis block of the corresponding chain (or at the `startBlock` defined with each data source) In some circumstances, it is beneficial to reuse the data from an existing subgraph and start indexing at a much later block. This mode of indexing is called _Grafting_. Grafting is, for example, useful during development to get past simple errors in the mappings quickly, or to temporarily get an existing subgraph working again after it has failed.
 
-> **Nota:** El grafting requiere que el indexador haya indexado el subgrafo base. No se recomienda en The Graph Network en este momento, y los desarrolladores no deberían desplegar subgrafos que utilicen esa funcionalidad en la red a través de Studio.
-
 A subgraph is grafted onto a base subgraph when the subgraph manifest in `subgraph.yaml` contains a `graft` block at the toplevel:
 
 ```yaml

--- a/pages/ja/developing/creating-a-subgraph.mdx
+++ b/pages/ja/developing/creating-a-subgraph.mdx
@@ -905,8 +905,6 @@ If the subgraph encounters an error that query will return both the data and a g
 
 When a subgraph is first deployed, it starts indexing events at the genesis block of the corresponding chain (or at the `startBlock` defined with each data source) In some circumstances, it is beneficial to reuse the data from an existing subgraph and start indexing at a much later block. This mode of indexing is called _Grafting_. Grafting is, for example, useful during development to get past simple errors in the mappings quickly, or to temporarily get an existing subgraph working again after it has failed.
 
-> **注: ** グラフト化には、インデクサがベースとなるサブグラフにインデックスを作成していることが必要です。現時点ではグラフネットワークでは推奨されておらず、開発者はその機能を使ったサブグラフをスタジオ経由でネットワークに展開してはいけません。
-
 A subgraph is grafted onto a base subgraph when the subgraph manifest in `subgraph.yaml` contains a `graft` block at the toplevel:
 
 ```yaml

--- a/pages/ko/developing/creating-a-subgraph.mdx
+++ b/pages/ko/developing/creating-a-subgraph.mdx
@@ -904,8 +904,6 @@ If the subgraph encounters an error that query will return both the data and a g
 
 When a subgraph is first deployed, it starts indexing events at the genesis block of the corresponding chain (or at the `startBlock` defined with each data source) In some circumstances, it is beneficial to reuse the data from an existing subgraph and start indexing at a much later block. This mode of indexing is called _Grafting_. Grafting is, for example, useful during development to get past simple errors in the mappings quickly, or to temporarily get an existing subgraph working again after it has failed.
 
-> **참고:** 접목은 인덱서의 기본 서브그래프 인덱싱을 필요로 합니다. 이는 현재 그래프 네트워크에서는 권장되지 않으며, 개발자는 해당 기능을 사용하여 Studio를 통해 네트워크에 서브그래프를 배포해서는 안 됩니다.
-
 A subgraph is grafted onto a base subgraph when the subgraph manifest in `subgraph.yaml` contains a `graft` block at the toplevel:
 
 ```yaml

--- a/pages/vi/developing/creating-a-subgraph.mdx
+++ b/pages/vi/developing/creating-a-subgraph.mdx
@@ -903,8 +903,6 @@ If the subgraph encounters an error that query will return both the data and a g
 
 When a subgraph is first deployed, it starts indexing events at the genesis block of the corresponding chain (or at the `startBlock` defined with each data source) In some circumstances, it is beneficial to reuse the data from an existing subgraph and start indexing at a much later block. This mode of indexing is called _Grafting_. Grafting is, for example, useful during development to get past simple errors in the mappings quickly, or to temporarily get an existing subgraph working again after it has failed.
 
-> **Lưu ý:** Việc ghép yêu cầu Indexer đã lập chỉ mục cho subgraph cơ sở. Nó không được khuyến nghị trên Mạng The Graph vào lúc này và các nhà phát triển không nên triển khai các subgraph sử dụng chức năng đó vào mạng thông qua Studio.
-
 A subgraph is grafted onto a base subgraph when the subgraph manifest in `subgraph.yaml` contains a `graft` block at the toplevel:
 
 ```yaml

--- a/pages/zh/developing/creating-a-subgraph.mdx
+++ b/pages/zh/developing/creating-a-subgraph.mdx
@@ -904,8 +904,6 @@ If the subgraph encounters an error that query will return both the data and a g
 
 When a subgraph is first deployed, it starts indexing events at the genesis block of the corresponding chain (or at the `startBlock` defined with each data source) In some circumstances, it is beneficial to reuse the data from an existing subgraph and start indexing at a much later block. This mode of indexing is called _Grafting_. Grafting is, for example, useful during development to get past simple errors in the mappings quickly, or to temporarily get an existing subgraph working again after it has failed.
 
-> **注意：** 嫁接需要索引器已经索引了基础子图。 目前不建议在 The Graph Network 上使用，开发人员不应通过 Studio 将使用该功能的子图部署到网络中。
-
 A subgraph is grafted onto a base subgraph when the subgraph manifest in `subgraph.yaml` contains a `graft` block at the toplevel:
 
 ```yaml


### PR DESCRIPTION
The current documentation has a recommendation to not use grafting. Should this be removed as it has been functional for enough time now?