### PR TITLE
Updating Indexer Options

### DIFF
--- a/pages/en/network/indexing.mdx
+++ b/pages/en/network/indexing.mdx
@@ -172,6 +172,8 @@ Note: To support agile scaling, it is recommended that query and indexing concer
 
 ### Setup server infrastructure using Terraform on Google Cloud
 
+> Note: Indexers can alternatively use AWS, Microsoft Azure, or Alibaba.
+
 #### Install prerequisites
 
 - Google Cloud SDK


### PR DESCRIPTION
Mentioning that Indexers can use alternatives to Google Cloud to run their indexing node.