### PR TITLE
Fixing benefits

### DIFF
--- a/pages/en/network/benefits.mdx
+++ b/pages/en/network/benefits.mdx
@@ -61,7 +61,7 @@ No contracts. No monthly fees. Only pay for the queries you use—with an averag
 | Engineering expense | $200 per hour | Included |
 | Geographic redundancy | $1,200 in total costs per additional node | Included |
 | Uptime | Varies | 99.9%+ |
-| Total Monthly Costs | <span className="highlight-row" /> $1,650+ per month | $750 per month |
+| Total Monthly Costs | <span className="highlight-row" /> $1,650+ | $750 |
 
 \*including costs for backup: $50-$100 per month
 
@@ -82,7 +82,7 @@ No contracts. No monthly fees. Only pay for the queries you use—with an averag
 | Infrastructure | Centralized | Decentralized |
 | Geographic redundancy | $1,200 in total costs per additional node | Included |
 | Uptime | Varies | 99.9%+ |
-| Total Monthly Costs | <span className="highlight-row" /> $11,000+ | $4,500 per month |
+| Total Monthly Costs | <span className="highlight-row" /> $11,000+ | $4,500 |
 
 \*including costs for backup: $50-$100 per month
 


### PR DESCRIPTION
Removing "per month" - it was redundant. 