### PR TITLE
fix studio billing urls to prod from staging

### DIFF
--- a/pages/en/billing.mdx
+++ b/pages/en/billing.mdx
@@ -16,7 +16,7 @@ While The Graph protocol operates on Ethereum Mainnet, [the billing contract](ht
 
 > This section is written assuming you already have GRT in your crypto wallet, and you're on Ethereum mainnet. If you don't have GRT, you can learn how to get GRT [here](#getting-grt).
 
-1. Go to the [Subgraph Studio Billing page](https://staging.thegraph.com/studio/billing/).
+1. Go to the [Subgraph Studio Billing page](https://thegraph.com/studio/billing/).
 
 2. Click on the "Connect Wallet" button on the top right corner of the page. You'll be redirected to the wallet selection page. Select your wallet and click on "Connect".
 
@@ -32,9 +32,9 @@ While The Graph protocol operates on Ethereum Mainnet, [the billing contract](ht
 
 ### Withdrawing GRT using a crypto wallet
 
-> This section is written assuming you have deposited GRT into your billing balance on [Subgraph Studio](https://staging.thegraph.com/studio/billing/) and that you're on the Arbitrum network.
+> This section is written assuming you have deposited GRT into your billing balance on [Subgraph Studio](https://thegraph.com/studio/billing/) and that you're on the Arbitrum network.
 
-1. Go to the [Subgraph Studio Billing page](https://staging.thegraph.com/studio/billing/).
+1. Go to the [Subgraph Studio Billing page](https://thegraph.com/studio/billing/).
 
 2. Click on the "Connect Wallet" button on the top right corner of the page. Select your wallet and click on "Connect".
 
@@ -48,7 +48,7 @@ While The Graph protocol operates on Ethereum Mainnet, [the billing contract](ht
 
 ### Adding GRT using a multisig wallet
 
-1. Go to the [Subgraph Studio Billing page](https://staging.thegraph.com/studio/billing/).
+1. Go to the [Subgraph Studio Billing page](https://thegraph.com/studio/billing/).
 
 2. Click on the "Connect Wallet" button on the top right corner of the page. Select your wallet and click on "Connect". If you're using [Gnosis-Safe](https://gnosis-safe.io/), you'll be able to connect your multisig as well as your signing wallet. Then, sign the associated message. This will not cost any gas.
 
@@ -58,9 +58,9 @@ While The Graph protocol operates on Ethereum Mainnet, [the billing contract](ht
 
 ### Withdrawing GRT using a multisig wallet
 
-> This section is written assuming you have deposited GRT into your billing balance on [Subgraph Studio](https://staging.thegraph.com/studio/billing/) and that you're on Ethereum mainnet.
+> This section is written assuming you have deposited GRT into your billing balance on [Subgraph Studio](https://thegraph.com/studio/billing/) and that you're on Ethereum mainnet.
 
-1. Go to the [Subgraph Studio Billing page](https://staging.thegraph.com/studio/billing/).
+1. Go to the [Subgraph Studio Billing page](https://thegraph.com/studio/billing/).
 
 2. Click on the "Connect Wallet" button on the top right corner of the page. Select your wallet and click on "Connect".
 


### PR DESCRIPTION
Fix for billing page, where Studio hyperlinks were incorrectly pointing to Staging env (https://staging.thegraph.com/studio/billing) instead of Production billing page (https://thegraph.com/studio/billing)

@graphprotocol/docs-reviewers 