### PR TITLE
Gnosis in beta fix

### DIFF
--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -260,6 +260,12 @@ const Index: NextPage<IndexProps> = ({ navItems }: IndexProps) => {
               image: '/img/networks/ethereum.svg',
               href: 'https://ethereum.org/en/',
             },
+            {
+              title: 'Gnosis Chain*',
+              image: '/img/networks/gnosis.svg',
+              href: 'https://docs.gnosischain.com/',
+              beta: true,
+            },
           ].map((network, index) => (
             <Flex.Column as="li" key={index}>
               <Text as="div" size="14px" color="White48" sx={{ textAlign: 'center' }}>
@@ -300,11 +306,6 @@ const Index: NextPage<IndexProps> = ({ navItems }: IndexProps) => {
           }}
         >
           {[
-            {
-              title: 'Gnosis Chain',
-              image: '/img/networks/gnosis.svg',
-              href: 'https://docs.gnosischain.com/',
-            },
             {
               title: 'Near',
               image: '/img/networks/near.svg',

--- a/pages/en/network-transition-faq.mdx
+++ b/pages/en/network-transition-faq.mdx
@@ -82,13 +82,15 @@ While Ethereum was initially anticipated to begin transition off of the hosted s
 
 The table below illustrates where each chain is in the network integration process. If your preferred chain is not yet listed, integration has not yet begun, and that chain is still fully supported by The Graph's hosted service.
 
+> This table will not include test chains, which remain free in [Subgraph Studio](https://thegraph.com/studio/).
+
 | Chain / Network | Announcing integration on The Graph Network | Network Integration complete | Phase 1: disable new subgraphs on hosted service | Phase 2: disable subgraph upgrades on hosted service | Phase 3: disable subgraphs on hosted service |
 | --- | :-: | :-: | :-: | :-: | :-: |
 | Ethereum | ✓ | ✓ |  |  |  |
-| Gnosis (formerly xDAI) | ✓ | ✓ |  |  |  |
+| Gnosis (formerly xDAI) | ✓ | ✓\* |  |  |  |
 | Polygon | ✓ |  |  |  |  |
 
-\*This table will not include test chains, which remain free in [Subgraph Studio](https://thegraph.com/studio/).
+\* The chain is currently in beta on The Graph's decentralized network.
 
 ## Query Fees, API Keys, and Billing FAQs
 


### PR DESCRIPTION
- Based on [this task](https://github.com/orgs/graphprotocol/projects/21/views/2?pane=issue&itemId=18990539)
- Gnosis didn't display the asterisk when I added the 'beta' value to 'true' so I just manually added the asterisk in the title itself