### PR TITLE
Move relationships two hierarchy levels up, to make them easier to find in the content section.

### DIFF
--- a/pages/en/developing/creating-a-subgraph.mdx
+++ b/pages/en/developing/creating-a-subgraph.mdx
@@ -261,13 +261,25 @@ Once the enum is defined in the schema, you can use the string representation of
 
 More detail on writing enums can be found in the [GraphQL documentation](https://graphql.org/learn/schema/).
 
-#### Entity Relationships
+#### Adding comments to the schema
+
+As per GraphQL spec, comments can be added above schema entity attributes using double quotations `""`. This is illustrated in the example below:
+
+```graphql
+type MyFirstEntity @entity {
+  "unique identifier and primary key of the entity"
+  id: Bytes!
+  address: Bytes!
+}
+```
+
+## Entity Relationships
 
 An entity may have a relationship to one or more other entities in your schema. These relationships may be traversed in your queries. Relationships in The Graph are unidirectional. It is possible to simulate bidirectional relationships by defining a unidirectional relationship on either "end" of the relationship.
 
 Relationships are defined on entities just like any other field except that the type specified is that of another entity.
 
-#### One-To-One Relationships
+### One-To-One Relationships
 
 Define a `Transaction` entity type with an optional one-to-one relationship with a `TransactionReceipt` entity type:
 
@@ -283,7 +295,7 @@ type TransactionReceipt @entity(immutable: true) {
 }
 ```
 
-#### One-To-Many Relationships
+### One-To-Many Relationships
 
 Define a `TokenBalance` entity type with a required one-to-many relationship with a Token entity type:
 
@@ -322,7 +334,7 @@ type TokenBalance @entity {
 }
 ```
 
-#### Many-To-Many Relationships
+### Many-To-Many Relationships
 
 For many-to-many relationships, such as users that each may belong to any number of organizations, the most straightforward, but generally not the most performant, way to model the relationship is as an array in each of the two entities involved. If the relationship is symmetric, only one side of the relationship needs to be stored and the other side can be derived.
 
@@ -382,18 +394,6 @@ query usersWithOrganizations {
 ```
 
 This more elaborate way of storing many-to-many relationships will result in less data stored for the subgraph, and therefore to a subgraph that is often dramatically faster to index and to query.
-
-#### Adding comments to the schema
-
-As per GraphQL spec, comments can be added above schema entity attributes using double quotations `""`. This is illustrated in the example below:
-
-```graphql
-type MyFirstEntity @entity {
-  "unique identifier and primary key of the entity"
-  id: Bytes!
-  address: Bytes!
-}
-```
 
 ## Defining Fulltext Search Fields
 


### PR DESCRIPTION
It was irritating that the relationships section cannot be found in the content summary. 

So I propose to "upgrade" the relationship section in such a way, that it shows up in the content section.

Also, the "comment" section needs to be moved before the relationship section, because it refers to entities in general, not to relationships.