### PR TITLE
ci: cancel previous runs when new commits are pushed

### DIFF
--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -14,6 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout the repo
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -10,6 +10,11 @@ jobs:
     if: contains(github.head_ref, 'crowdin') == false
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout the repo
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -15,6 +15,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout the repo
         uses: actions/checkout@v2
 

--- a/.github/workflows/website-integrity.yml
+++ b/.github/workflows/website-integrity.yml
@@ -9,6 +9,11 @@ jobs:
   website-check:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v3
       - name: Fetch


### PR DESCRIPTION
this is to optimize and save long running CI if you are pushing to branch constantly.
