### PR TITLE
Suggest the use of "Token ID" to deprecate the subgraph via Etherscan

### DIFF
--- a/website/pages/en/managing/deprecating-a-subgraph.mdx
+++ b/website/pages/en/managing/deprecating-a-subgraph.mdx
@@ -5,7 +5,7 @@ title: Deprecating a Subgraph
 So you'd like to deprecate your subgraph on The Graph Explorer. You've come to the right place! Follow the steps below:
 
 1. Visit the contract address [here](https://etherscan.io/address/0xadca0dd4729c8ba3acf3e99f3a9f471ef37b6825#writeProxyContract)
-2. Call 'deprecateSubgraph' with your 'SubgraphID'
+2. Call 'deprecateSubgraph' with your subgraph's 'Token ID'
 3. Voila! Your subgraph will no longer show up on searches on The Graph Explorer. Please note the following:
 
 - The 'deprecateSubgraph' function should be called by the owner's wallet.


### PR DESCRIPTION
The 'SubgraphId' is presented in a base58 representation in the dashboards, which is not accepted on Etherscan uint256 parameters.

The Token Id, on the other hand, uses the decimal representation, which is accepted on Etherscan.