### PR TITLE
fix: `getRewards` contract function URL

### DIFF
--- a/website/pages/en/network/indexing.mdx
+++ b/website/pages/en/network/indexing.mdx
@@ -38,7 +38,7 @@ Allocations are continuously accruing rewards while they're active and allocated
 
 ### Can pending indexing rewards be monitored?
 
-The RewardsManager contract has a read-only [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L317) function that can be used to check the pending rewards for a specific allocation.
+The RewardsManager contract has a read-only [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L371) function that can be used to check the pending rewards for a specific allocation.
 
 Many of the community-made dashboards include pending rewards values and they can be easily checked manually by following these steps:
 

--- a/website/pages/es/network/indexing.mdx
+++ b/website/pages/es/network/indexing.mdx
@@ -38,7 +38,7 @@ Las asignaciones acumulan recompensas continuamente mientras están activas. Los
 
 ### ¿Se pueden monitorear las recompensas pendientes del indexador?
 
-El contrato de RewardsManager tiene una función [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L317) de solo lectura que se puede usar para comprobar las recompensas pendientes para una asignación específica.
+El contrato de RewardsManager tiene una función [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L371) de solo lectura que se puede usar para comprobar las recompensas pendientes para una asignación específica.
 
 Muchos de los paneles creados por la comunidad incluyen valores de recompensas pendientes y se pueden verificar fácilmente de forma manual siguiendo estos pasos:
 

--- a/website/pages/ur/network/indexing.mdx
+++ b/website/pages/ur/network/indexing.mdx
@@ -38,7 +38,7 @@ POIs کو نیٹ ورک میں اس بات کی تصدیق کرنے کے لیے 
 
 ### کیا زیر غور انڈیکسنگ کے انعامات کی نگرانی کی جا سکتی ہے؟
 
-RewardsManager کنٹریکٹ میں صرف پڑھنے کے لیے [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L317) فنکشن ہوتا ہے جسے مخصوص مختص کے لیے زیر التواء انعامات کو چیک کرنے کے لیے استعمال کیا جا سکتا ہے.
+RewardsManager کنٹریکٹ میں صرف پڑھنے کے لیے [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L371) فنکشن ہوتا ہے جسے مخصوص مختص کے لیے زیر التواء انعامات کو چیک کرنے کے لیے استعمال کیا جا سکتا ہے.
 
 کمیونٹی کے بنائے ہوئے بہت سے ڈیش بورڈز میں زیر التواء انعامات کی قدریں شامل ہیں اور ان اقدامات پر عمل کر کے انہیں آسانی سے دستی طور پر چیک کیا جا سکتا ہے:
 

--- a/website/pages/vi/network/indexing.mdx
+++ b/website/pages/vi/network/indexing.mdx
@@ -38,7 +38,7 @@ Việc phân bổ liên tục tích lũy phần thưởng khi chúng đang hoạ
 
 ### Có thể giám sát phần thưởng indexer đang chờ xử lý không?
 
-Hợp đồng RewardsManager có có một chức năng [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L317) chỉ đọc có thể được sử dụng để kiểm tra phần thưởng đang chờ để phân bổ cụ thể.
+Hợp đồng RewardsManager có có một chức năng [getRewards](https://github.com/graphprotocol/contracts/blob/master/contracts/rewards/RewardsManager.sol#L371) chỉ đọc có thể được sử dụng để kiểm tra phần thưởng đang chờ để phân bổ cụ thể.
 
 Nhiều trang tổng quan (dashboard) do cộng đồng tạo bao gồm các giá trị phần thưởng đang chờ xử lý và bạn có thể dễ dàng kiểm tra chúng theo cách thủ công bằng cách làm theo các bước sau:
 


### PR DESCRIPTION
The old link pointed to an unrelated part of the source file.