### PR TITLE
docs: update smart contract access details

### DIFF
--- a/website/pages/en/developing/assemblyscript-api.mdx
+++ b/website/pages/en/developing/assemblyscript-api.mdx
@@ -462,7 +462,25 @@ export function handleTransfer(event: TransferEvent) {
 
 As long as the `ERC20Contract` on Ethereum has a public read-only function called `symbol`, it can be called with `.symbol()`. For public state variables a method with the same name is created automatically.
 
-Any other contract that is part of the subgraph can be imported from the generated code and can be bound to a valid address.
+Any other contract that is part of the subgraph can be imported from the generated code and can be bound to a valid address. Example of that is presented within the steps below:
+
+- extend `subgraph.yaml` file with desired ABI file:
+
+```yaml
+mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Gravatar
+      abis:
+        - name: Gravity
+          file: ./abis/Gravity.json
+        - name: OtherContract
+          file: ./abis/OtherContract.json
+```
+
+- import and bind to the contract using its address.
 
 #### Handling Reverted Calls
 

--- a/website/pages/en/developing/assemblyscript-api.mdx
+++ b/website/pages/en/developing/assemblyscript-api.mdx
@@ -468,16 +468,16 @@ Any other contract that is part of the subgraph can be imported from the generat
 
 ```yaml
 mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.6
-      language: wasm/assemblyscript
-      entities:
-        - Gravatar
-      abis:
-        - name: Gravity
-          file: ./abis/Gravity.json
-        - name: OtherContract
-          file: ./abis/OtherContract.json
+  kind: ethereum/events
+  apiVersion: 0.0.6
+  language: wasm/assemblyscript
+  entities:
+    - Gravatar
+  abis:
+    - name: Gravity
+      file: ./abis/Gravity.json
+    - name: OtherContract
+      file: ./abis/OtherContract.json
 ```
 
 - import and bind to the contract using its address.


### PR DESCRIPTION
Proposition to clarify an option for calling contract unrelated to event/function/log origin.