### PR TITLE
Hide locale switcher on `/en/substreams` pages

### DIFF
--- a/website/components/_app.tsx
+++ b/website/components/_app.tsx
@@ -57,9 +57,10 @@ const DefaultSeoWithLocale = () => {
   return <DefaultSeo {...seoProps} />
 }
 
-const localeSwitcher = <LocaleSwitcher key="localeSwitcher" />
-
 function MyApp({ Component, pageProps, router }: AppProps): ReactElement {
+  const hideLocaleSwitcher = pageProps.hideLocaleSwitcher ?? false
+  const localeSwitcher = hideLocaleSwitcher ? null : <LocaleSwitcher key="localeSwitcher" />
+
   return (
     <I18nProvider supportedLocales={supportedLocales} translations={translations} clientRouter={router}>
       <DefaultSeoWithLocale />
@@ -92,7 +93,11 @@ function MyApp({ Component, pageProps, router }: AppProps): ReactElement {
           <Layout
             headerSticky
             headerContent={
-              <NavigationMarketing activeRoute="/docs" NextLink={NextLink} rightAlignItems={[localeSwitcher]} />
+              <NavigationMarketing
+                activeRoute="/docs"
+                NextLink={NextLink}
+                rightAlignItems={localeSwitcher ? [localeSwitcher] : undefined}
+              />
             }
             mainContainer
             footerContent={<Footer localeSwitcher={localeSwitcher} />}

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -48,8 +48,8 @@ export default withNextra({
       permanent: false,
     },
     {
-      source: '/en/substreams',
-      destination: '/en/substreams/README',
+      source: '/en/substreams/',
+      destination: '/en/substreams/README/',
       permanent: false,
     },
   ],

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -47,6 +47,11 @@ export default withNextra({
       destination: '/en/',
       permanent: false,
     },
+    {
+      source: '/en/substreams',
+      destination: '/en/substreams/README',
+      permanent: false,
+    },
   ],
   webpack(config) {
     config.module.rules.push({

--- a/website/pages/en/substreams/[[...slug]].mdx
+++ b/website/pages/en/substreams/[[...slug]].mdx
@@ -46,6 +46,7 @@ export async function getStaticProps({ params: { slug = ['README'] } }) {
     props: {
       ...mdx,
       __nextra_pageMap: await getPageMap('en'),
+      hideLocaleSwitcher: true,
     },
   }
 }

--- a/website/route-lockfile.txt
+++ b/website/route-lockfile.txt
@@ -151,6 +151,7 @@
 /en/querying/querying-the-hosted-service/
 /en/release-notes/assemblyscript-migration-guide/
 /en/release-notes/graphql-validations-migration-guide/
+/en/substreams/ -> /en/substreams/README/
 /en/substreams/README/
 /en/substreams/concepts-and-fundamentals/benefits/
 /en/substreams/concepts-and-fundamentals/fundamentals/


### PR DESCRIPTION
Targeting the `substreams` branch (PR #346). This is a workaround until the substreams docs are translated somehow (probably through Crowdin too, but set up in the remote repo).