### PR TITLE
Ignore `[[...slug]].mdx` in Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,6 +4,8 @@ files:
     translation: /website/pages/%two_letters_code%/**/%original_file_name%
     dest: /**/%original_file_name%
     content_segmentation: 0
+    ignore:
+      - /website/pages/en/substreams/[[...slug]].mdx
   - source: /website/pages/en/**/*.json
     translation: /website/pages/%two_letters_code%/**/%original_file_name%
     dest: /**/%original_file_name%


### PR DESCRIPTION
This PR makes Crowdin ignore [`/website/pages/en/substreams/[[...slug]].mdx`](https://github.com/graphprotocol/docs/blob/main/website/pages/en/substreams/%5B%5B...slug%5D%5D.mdx), as it's only code and not meant to be translatable (Crowdin docs for this feature [here](https://developer.crowdin.com/configuration-file/#ignoring-files-and-directories)).

Recommended by @B2o5T in [this comment](https://github.com/graphprotocol/docs/pull/360#issuecomment-1532816119).