### PR TITLE
Add `/en/substreams/` => `/en/substreams/README/` redirect to Nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -45,8 +45,9 @@ http {
         rewrite ^/([^.]*[^/])$  $scheme://$http_host/$1/    permanent; # force a trailing slash except for files with an extension
 
         # Permanent redirects (301)
-        rewrite ^/docs/hostedservice/(.*)$                              $scheme://$http_host/docs/en/hosted-service/$1  permanent;
-        rewrite ^/docs/(?!(?:[a-zA-Z][a-zA-Z]|_next|img)(?:/|$))(.*)$   $scheme://$http_host/docs/en/$1                 permanent; # Redirect to `/en` if no language in URL and not an asset URL
+        rewrite ^/docs/hostedservice/(.*)$                              $scheme://$http_host/docs/en/hosted-service/$1      permanent;
+        rewrite ^/docs/(?!(?:[a-zA-Z][a-zA-Z]|_next|img)(?:/|$))(.*)$   $scheme://$http_host/docs/en/$1                     permanent; # Redirect to `/en` if no language in URL and not an asset URL
+        rewrite ^/docs/en/substreams/$                                  $scheme://$http_host/docs/en/substreams/README/     permanent;
 
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/about/introduction/$                          $scheme://$http_host/docs/$1/about/                                         permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/about/network/$                               $scheme://$http_host/docs/$1/network/overview/                              permanent;


### PR DESCRIPTION
This fixes the following issue when going from the Substreams page in another language to English (video from staging):

https://github.com/graphprotocol/docs/assets/1059139/d96744c3-4e63-4725-83fe-104425801f1f
