### PR TITLE
Update docs for indexer setup

### DIFF
--- a/website/pages/en/operating-graph-node.mdx
+++ b/website/pages/en/operating-graph-node.mdx
@@ -69,33 +69,6 @@ cargo run -p graph-node --release -- \
   --ipfs https://ipfs.network.thegraph.com
 ```
 
-### Getting started using Docker
-
-#### Prerequisites
-
-- **Ethereum node** - By default, the docker compose setup will use mainnet: [http://host.docker.internal:8545](http://host.docker.internal:8545) to connect to the Ethereum node on your host machine. You can replace this network name and url by updating `docker-compose.yml`.
-
-#### Setup
-
-1. Clone Graph Node and navigate to the Docker directory:
-
-```sh
-git clone http://github.com/graphprotocol/graph-node
-cd graph-node/docker
-```
-
-2. For linux users only - Use the host IP address instead of `host.docker.internal` in the `docker-compose.yml`using the included script:
-
-```sh
-./setup.sh
-```
-
-3. Start a local Graph Node that will connect to your Ethereum endpoint:
-
-```sh
-docker-compose up
-```
-
 ### Getting started with Kubernetes
 
 A complete Kubernetes example configuration can be found in the [indexer repository](https://github.com/graphprotocol/indexer/tree/main/k8s).


### PR DESCRIPTION
The docker-compose setup is designed specifically for graph-node devs, so I'm removing reference of it from the docs for network indexers. The removed section can likely be replaced later with a section on using the [stakesquid docker-compose setup](https://github.com/StakeSquid/graphprotocol-mainnet-docker) which was designed for use by indexers and includes the other necessary components of the indexer stack.