### PR TITLE
Added Goerli GRT contract addresses

### DIFF
--- a/website/pages/en/network-transition-faq.mdx
+++ b/website/pages/en/network-transition-faq.mdx
@@ -220,7 +220,9 @@ Yes, multisig support has recently been added. You can find more information [he
 ### What are the contract addresses for GRT on Ethereum and Arbitrum?
 
 - Ethereum: `0xc944E90C64B2c07662A292be6244BDf05Cda44a7`
+- Ethereum Goerli: `0x5c946740441C12510a167B447B7dE565C20b9E3C`
 - Arbitrum: `0x9623063377AD1B27544C965cCd7342f7EA7e88C7`
+- Arbitrum Goerli: `0x18c924bd5e8b83b47efadd632b7178e2fd36073d`
 
 ### How much GRT do projects usually keep in their API Key?
 


### PR DESCRIPTION
Docs were missing the Goerli GRT contract addresses for Ethereum and Arbitrum.