### PR TITLE
Rename Substreams > “Quick Start” to “Introduction”

### DIFF
--- a/website/pages/en/substreams/_meta.js
+++ b/website/pages/en/substreams/_meta.js
@@ -28,7 +28,7 @@ export async function listFiles() {
 
 export default async () => {
   return createCatchAllMeta(await listFiles(), {
-    README: 'Quick Start',
+    README: 'Introduction',
     'concepts-and-fundamentals': {
       type: 'folder',
       items: {


### PR DESCRIPTION
From Alex:

> Quickstart has a defined meaning in docs-land. And there’s a page for that here: https://thegraph.com/docs/en/substreams/getting-started/quickstart/