### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Install the dependencies:
 pnpm install
 ```
 
+Build the project:
+
+```bash
+pnpm build
+```
+
 Then, run the project:
 
 ```bash


### PR DESCRIPTION
It would be helpful to state that `pnpm build` needs to be run first before running `pnpm dev`
The page doesn't load if you don't build first. Took me a while to figure it out. 