### PR TITLE
Add 302 redirect from `/en/firehose/` to `/en/firehose/README/`

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,7 +47,6 @@ http {
         # Permanent redirects (301)
         rewrite ^/docs/hostedservice/(.*)$                              $scheme://$http_host/docs/en/hosted-service/$1      permanent;
         rewrite ^/docs/(?!(?:[a-zA-Z][a-zA-Z]|_next|img)(?:/|$))(.*)$   $scheme://$http_host/docs/en/$1                     permanent; # Redirect to `/en` if no language in URL and not an asset URL
-        rewrite ^/docs/en/substreams/$                                  $scheme://$http_host/docs/en/substreams/README/     permanent;
 
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/about/introduction/$                          $scheme://$http_host/docs/$1/about/                                         permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/about/network/$                               $scheme://$http_host/docs/$1/network/overview/                              permanent;
@@ -85,6 +84,10 @@ http {
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/supported-networks/cosmos/$                   $scheme://$http_host/docs/$1/cookbook/cosmos/                               permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/supported-networks/near/$                     $scheme://$http_host/docs/$1/cookbook/near/                                 permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/developing/defining-a-subgraph/$              $scheme://$http_host/docs/$1/developing/creating-a-subgraph/                permanent;
+
+        # Temporary redirects (302)
+        rewrite ^/docs/en/substreams/$      $scheme://$http_host/docs/en/substreams/README/     redirect;
+        rewrite ^/docs/en/firehose/$        $scheme://$http_host/docs/en/firehose/README/       redirect;
 
         location / {
             try_files $uri $uri.html $uri/index.html =404;

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -52,6 +52,11 @@ export default withNextra({
       destination: '/en/substreams/README/',
       permanent: false,
     },
+    {
+      source: '/en/firehose/',
+      destination: '/en/firehose/README/',
+      permanent: false,
+    },
   ],
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
Like #378 but for the Firehose docs, this prevents a 403 when switching from a non-English language to English while on the Firehose page.