### PR TITLE
Migrate to upgrade

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -84,7 +84,8 @@ http {
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/supported-networks/cosmos/$                   $scheme://$http_host/docs/$1/cookbook/cosmos/                               permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/supported-networks/near/$                     $scheme://$http_host/docs/$1/cookbook/near/                                 permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/developing/defining-a-subgraph/$              $scheme://$http_host/docs/$1/developing/creating-a-subgraph/                permanent;
-        rewrite ^/docs/([a-zA-Z][a-zA-Z])/arbitrum-faq/$                                $scheme://$http_host/docs/$1/arbitrum/arbitrum-faq/                                  permanent;
+        rewrite ^/docs/([a-zA-Z][a-zA-Z])/arbitrum-faq/$                                $scheme://$http_host/docs/$1/arbitrum/arbitrum-faq/                         permanent;
+        rewrite ^/docs/([a-zA-Z][a-zA-Z])/cookbook/migrating-a-subgraph/$               $scheme://$http_host/docs/$1/cookbook/upgrading-a-subgraph/                 permanent;
 
         # Temporary redirects (302)
         rewrite ^/docs/en/firehose/$                $scheme://$http_host/docs/en/firehose/README/               redirect;

--- a/website/pages/en/arbitrum/arbitrum-faq.mdx
+++ b/website/pages/en/arbitrum/arbitrum-faq.mdx
@@ -14,7 +14,7 @@ By scaling The Graph on L2, network participants can expect:
 
 - Security inherited from Ethereum
 
-Scaling the protocol smart contracts onto L2 allows network participants to interact more frequently at a reduced cost in gas fees. For example, Indexers could open and close allocations to index a greater number of subgraphs with greater frequency, developers could deploy and upgrade subgraphs with greater ease, Delegators could delegate GRT with increased frequency, and Curators could add or remove signal to a larger number of subgraphs–actions previously considered too cost-prohibitive to perform frequently due to gas.
+Scaling the protocol smart contracts onto L2 allows network participants to interact more frequently at a reduced cost in gas fees. For example, Indexers could open and close allocations to index a greater number of subgraphs with greater frequency, developers could deploy and update subgraphs with greater ease, Delegators could delegate GRT with increased frequency, and Curators could add or remove signal to a larger number of subgraphs–actions previously considered too cost-prohibitive to perform frequently due to gas.
 
 The Graph community decided to move forward with Arbitrum last year after the outcome of the [GIP-0031](https://forum.thegraph.com/t/gip-0031-arbitrum-grt-bridge/3305) discussion.
 

--- a/website/pages/en/arbitrum/l2-transfer-tools-guide.mdx
+++ b/website/pages/en/arbitrum/l2-transfer-tools-guide.mdx
@@ -14,7 +14,7 @@ Some frequent questions about these tools are answered in the [L2 Transfer Tools
 
 The Graph's community and core devs have [been preparing](https://forum.thegraph.com/t/gip-0031-arbitrum-grt-bridge/3305) to move to Arbitrum over the past year. Arbitrum, a layer 2 or "L2" blockchain, inherits the security from Ethereum but provides drastically lower gas fees.
 
-When you publish or upgrade your subgraphs to The Graph Network, you're interacting with smart contracts in the protocol and this requires paying for gas using ETH. By moving your subgraphs to Arbitrum, any future upgrades to your subgraph will require much lower gas fees. The lower fees, and the fact that curation bonding curves on L2 are flat, also make it easier for other Curators to curate on your subgraph, increasing the rewards for Indexers on your subgraph. This lower-cost environment also makes it cheaper for Indexers to index and serve your subgraph. Indexing rewards will be increasing on Arbitrum and decreasing on Ethereum mainnet over the coming months, so more and more Indexers will be transferring their stake and setting up their operations on L2.
+When you publish or upgrade your subgraph to The Graph Network, you're interacting with smart contracts on the protocol and this requires paying for gas using ETH. By moving your subgraphs to Arbitrum, any future updates to your subgraph will require much lower gas fees. The lower fees, and the fact that curation bonding curves on L2 are flat, also make it easier for other Curators to curate on your subgraph, increasing the rewards for Indexers on your subgraph. This lower-cost environment also makes it cheaper for Indexers to index and serve your subgraph. Indexing rewards will be increasing on Arbitrum and decreasing on Ethereum mainnet over the coming months, so more and more Indexers will be transferring their stake and setting up their operations on L2.
 
 ## Understanding what happens with signal, your L1 subgraph and query URLs
 
@@ -30,7 +30,7 @@ Queries to the L2 subgraph will need to be done to a different URL (on `arbitrum
 
 ## Choosing your L2 wallet
 
-When you published your subgraph on mainnet, you used a connected wallet to create the subgraph, and this wallet owns the NFT that represents this subgraph and allows you to publish upgrades.
+When you published your subgraph on mainnet, you used a connected wallet to create the subgraph, and this wallet owns the NFT that represents this subgraph and allows you to publish updates.
 
 When transferring the subgraph to Arbitrum, you can choose a different wallet that will own this subgraph NFT on L2.
 

--- a/website/pages/en/cookbook/_meta.js
+++ b/website/pages/en/cookbook/_meta.js
@@ -1,7 +1,7 @@
 export default {
   'quick-start': '',
   'base-testnet': '',
-  'migrating-a-subgraph': '',
+  'upgrading-a-subgraph': '',
   'subgraph-debug-forking': '',
   near: '',
   cosmos: '',

--- a/website/pages/en/cookbook/upgrading-a-subgraph.mdx
+++ b/website/pages/en/cookbook/upgrading-a-subgraph.mdx
@@ -71,7 +71,7 @@ graph deploy --studio <SUBGRAPH_SLUG>
 6. At this point, your subgraph is now deployed on Subgraph Studio, but not yet published to the decentralized network. You can now test the subgraph to make sure it is working as intended using the temporary query URL as seen on top of the right column above. As this name already suggests, this is a temporary URL and should not be used in production.
 
 - Updating is just publishing another version of your existing subgraph on-chain.
-- Publishing is an on-chain action and will require gas to be paid for in Ethereum - see an example transaction [here](https://etherscan.io/tx/0xd0c3fa0bc035703c9ba1ce40c1862559b9c5b6ea1198b3320871d535aa0de87b). Prices are roughly around 0.0425 ETH at 100 gwei.
+- Because this incurs a cost, it is highly recommended to deploy and test your subgraph in the Subgraph Studio, using the "Development Query URL" before publishing. See an example transaction [here](https://etherscan.io/tx/0xd0c3fa0bc035703c9ba1ce40c1862559b9c5b6ea1198b3320871d535aa0de87b). Prices are roughly around 0.0425 ETH at 100 gwei.
 - Any time you need to update your subgraph, you will be charged an update fee. Because this incurs a cost, it is highly recommended to deploy and test your subgraph on Goerli before deploying to mainnet. It can, in some cases, also require some GRT if there is no signal on that subgraph. In the case there is signal/curation on that subgraph version (using auto-migrate), the taxes will be split.
 
 7. Publish the subgraph on The Graph's decentralized network by hitting the "Publish" button.

--- a/website/pages/en/cookbook/upgrading-a-subgraph.mdx
+++ b/website/pages/en/cookbook/upgrading-a-subgraph.mdx
@@ -4,16 +4,16 @@ title: Upgrading an Existing Subgraph to The Graph Network
 
 ## Introduction
 
-This is a guide on how to upgrade your subgraph from the hosted service to The Graph's decentralized network. Upgrading to The Graph Network has been successful for projects like Opyn, UMA, mStable, Audius, PoolTogether, Livepeer, RAI, Enzyme, DODO, Pickle, and BadgerDAO all of which are relying on data served by Indexers on the network. There are now over 700 subgraphs live on The Graph's decentralized network, generating query fees and actively indexing web3 data.
+This is a guide on how to upgrade your subgraph from the hosted service to The Graph's decentralized network. Over 1,000 subgraphs have successfully upgraded to The Graph Network including projects like Snapshot, Loopring, Audius, Premia, Livepeer, Uma, Curve, Lido, and many more!
 
 The process of upgrading is quick and your subgraphs will forever benefit from the reliability and performance that you can only get on The Graph Network.
 
-### Assumptions
+### Prerequisites
 
 - You have already deployed a subgraph on the hosted service.
 - The subgraph is indexing a chain available (or available in beta) on The Graph Network.
-- The subgraph does not use `ipfs.cat` in handler functions.
-- The subgraph does not have full-text search dependencies (it is not fully supported on the decentralized network yet).
+- You have a wallet with ETH to publish your subgraph on-chain.
+- You have ~10,000 GRT to curate your subgraph so Indexers can begin indexing it.
 
 ## Upgrading an Existing Subgraph to The Graph Network
 
@@ -70,10 +70,13 @@ graph deploy --studio <SUBGRAPH_SLUG>
 
 6. At this point, your subgraph is now deployed on Subgraph Studio, but not yet published to the decentralized network. You can now test the subgraph to make sure it is working as intended using the temporary query URL as seen on top of the right column above. As this name already suggests, this is a temporary URL and should not be used in production.
 
+- Updating is just publishing another version of your existing subgraph on-chain.
 - Publishing is an on-chain action and will require gas to be paid for in Ethereum - see an example transaction [here](https://etherscan.io/tx/0xd0c3fa0bc035703c9ba1ce40c1862559b9c5b6ea1198b3320871d535aa0de87b). Prices are roughly around 0.0425 ETH at 100 gwei.
-- Any time you need to update your subgraph, you will be charged an update fee. Updating is just publishing another version of your existing subgraph on-chain. Because this incurs a cost, it is highly recommended to deploy and test your subgraph on Goerli before deploying to mainnet. It can, in some cases, also require some GRT if there is no signal on that subgraph. In the case there is signal/curation on that subgraph version (using auto-migrate), the taxes will be split.
+- Any time you need to update your subgraph, you will be charged an update fee. Because this incurs a cost, it is highly recommended to deploy and test your subgraph on Goerli before deploying to mainnet. It can, in some cases, also require some GRT if there is no signal on that subgraph. In the case there is signal/curation on that subgraph version (using auto-migrate), the taxes will be split.
 
 7. Publish the subgraph on The Graph's decentralized network by hitting the "Publish" button.
+
+You should curate your subgraph with GRT to ensure that it is indexed by Indexers. To save on gas costs, you can curate your subgraph in the same transaction that you publish it to the network. It is recommended to curate your subgraph with at least 10,000 GRT for high quality of service.
 
 And that's it! After you are done publishing, you'll be able to view your subgraphs live on the decentralized network via [The Graph Explorer](https://thegraph.com/explorer).
 
@@ -154,6 +157,8 @@ graph deploy --studio <SUBGRAPH_SLUG>
 4. Publish the new version on The Graph Network. Remember that this requires gas (as described in the section above).
 
 ### Owner Update Fee: Deep Dive
+
+> Note: Curation on Arbitrum does not use bonding curves. Learn more about Arbitrum [here](/arbitrum/arbitrum-faq/).
 
 An update requires GRT to be migrated from the old version of the subgraph to the new version. This means that for every update, a new bonding curve will be created (more on bonding curves [here](/network/curating#bonding-curve-101)).
 

--- a/website/pages/en/cookbook/upgrading-a-subgraph.mdx
+++ b/website/pages/en/cookbook/upgrading-a-subgraph.mdx
@@ -1,12 +1,12 @@
 ---
-title: Migrating an Existing Subgraph to The Graph Network
+title: Upgrade an Existing Subgraph to The Graph Network
 ---
 
 ## Introduction
 
-This is a guide on how to migrate your subgraph from the Hosted Service to The Graph's decentralized network. Migration to The Graph Network has been successful for projects like Opyn, UMA, mStable, Audius, PoolTogether, Livepeer, RAI, Enzyme, DODO, Pickle, and BadgerDAO all of which are relying on data served by Indexers on the network. There are now over 700 subgraphs live on The Graph's decentralized network, generating query fees and actively indexing web3 data.
+This is a guide on how to upgrade your subgraph from the hosted service to The Graph's decentralized network. Upgrading to The Graph Network has been successful for projects like Opyn, UMA, mStable, Audius, PoolTogether, Livepeer, RAI, Enzyme, DODO, Pickle, and BadgerDAO all of which are relying on data served by Indexers on the network. There are now over 700 subgraphs live on The Graph's decentralized network, generating query fees and actively indexing web3 data.
 
-The process of migration is quick and your subgraphs will forever benefit from the reliability and performance that you can only get on The Graph Network.
+The process of Upgrading is quick and your subgraphs will forever benefit from the reliability and performance that you can only get on The Graph Network.
 
 ### Assumptions
 
@@ -15,7 +15,7 @@ The process of migration is quick and your subgraphs will forever benefit from t
 - The subgraph does not use `ipfs.cat` in handler functions.
 - The subgraph does not have full-text search dependencies (it is not fully supported on the decentralized network yet).
 
-## Migrating an Existing Subgraph to The Graph Network
+## Upgrading an Existing Subgraph to The Graph Network
 
 > You can find specific commands for your subgraph in the [Subgraph Studio](https://thegraph.com/studio/).
 
@@ -71,7 +71,7 @@ graph deploy --studio <SUBGRAPH_SLUG>
 6. At this point, your subgraph is now deployed on Subgraph Studio, but not yet published to the decentralized network. You can now test the subgraph to make sure it is working as intended using the temporary query URL as seen on top of the right column above. As this name already suggests, this is a temporary URL and should not be used in production.
 
 - Publishing is an on-chain action and will require gas to be paid for in Ethereum - see an example transaction [here](https://etherscan.io/tx/0xd0c3fa0bc035703c9ba1ce40c1862559b9c5b6ea1198b3320871d535aa0de87b). Prices are roughly around 0.0425 ETH at 100 gwei.
-- Any time you need to upgrade your subgraph, you will be charged an upgrade fee. Upgrading is just publishing another version of your existing subgraph on-chain. Because this incurs a cost, it is highly recommended to deploy and test your subgraph on Goerli before deploying to mainnet. It can, in some cases, also require some GRT if there is no signal on that subgraph. In the case there is signal/curation on that subgraph version (using auto-migrate), the taxes will be split.
+- Any time you need to update your subgraph, you will be charged an update fee. Updating is just publishing another version of your existing subgraph on-chain. Because this incurs a cost, it is highly recommended to deploy and test your subgraph on Goerli before deploying to mainnet. It can, in some cases, also require some GRT if there is no signal on that subgraph. In the case there is signal/curation on that subgraph version (using auto-migrate), the taxes will be split.
 
 7. Publish the subgraph on The Graph's decentralized network by hitting the "Publish" button.
 
@@ -139,9 +139,9 @@ Congratulations! You are now a pioneer of decentralization!
 
 More information about the nature of the network and how to handle re-orgs are described in the documentation article [Distributed Systems](/querying/distributed-systems/).
 
-## Upgrading a Subgraph on the Network
+## Updating a Subgraph on the Network
 
-If you would like to upgrade an existing subgraph on the network, you can do this by deploying a new version of your subgraph to the Subgraph Studio using the Graph CLI.
+If you would like to update an existing subgraph on the network, you can do this by deploying a new version of your subgraph to the Subgraph Studio using the Graph CLI.
 
 1. Make changes to your current subgraph. A good idea is to test small fixes on the Subgraph Studio by publishing to Goerli.
 2. Deploy the following and specify the new version in the command (eg. v0.0.1, v0.0.2, etc):
@@ -153,23 +153,23 @@ graph deploy --studio <SUBGRAPH_SLUG>
 3. Test the new version in the Subgraph Studio by querying in the playground
 4. Publish the new version on The Graph Network. Remember that this requires gas (as described in the section above).
 
-### Owner Upgrade Fee: Deep Dive
+### Owner Update Fee: Deep Dive
 
-An upgrade requires GRT to be migrated from the old version of the subgraph to the new version. This means that for every upgrade, a new bonding curve will be created (more on bonding curves [here](/network/curating#bonding-curve-101)).
+An update requires GRT to be migrated from the old version of the subgraph to the new version. This means that for every update, a new bonding curve will be created (more on bonding curves [here](/network/curating#bonding-curve-101)).
 
-The new bonding curve charges the 1% curation tax on all GRT being migrated to the new version. The owner must pay 50% of this or 1.25%. The other 1.25% is absorbed by all the curators as a fee. This incentive design is in place to prevent an owner of a subgraph from being able to drain all their curator's funds with recursive upgrade calls. If there is no curation activity, you will have to pay a minimum of 100 GRT in order to signal your own subgraph.
+The new bonding curve charges the 1% curation tax on all GRT being migrated to the new version. The owner must pay 50% of this or 1.25%. The other 1.25% is absorbed by all the curators as a fee. This incentive design is in place to prevent an owner of a subgraph from being able to drain all their curator's funds with recursive update calls. If there is no curation activity, you will have to pay a minimum of 100 GRT in order to signal your own subgraph.
 
 Let's make an example, this is only the case if your subgraph is being actively curated on:
 
 - 100,000 GRT is signaled using auto-migrate on v1 of a subgraph
-- Owner upgrades to v2. 100,000 GRT is migrated to a new bonding curve, where 97,500 GRT get put into the new curve and 2,500 GRT is burned
-- The owner then has 1250 GRT burned to pay for half the fee. The owner must have this in their wallet before the upgrade, otherwise, the upgrade will not succeed. This happens in the same transaction as the upgrade.
+- Owner updates to v2. 100,000 GRT is migrated to a new bonding curve, where 97,500 GRT get put into the new curve and 2,500 GRT is burned
+- The owner then has 1250 GRT burned to pay for half the fee. The owner must have this in their wallet before the update, otherwise, the update will not succeed. This happens in the same transaction as the update.
 
-_While this mechanism is currently live on the network, the community is currently discussing ways to reduce the cost of upgrades for subgraph developers._
+_While this mechanism is currently live on the network, the community is currently discussing ways to reduce the cost of updates for subgraph developers._
 
 ### Maintaining a Stable Version of a Subgraph
 
-If you're making a lot of changes to your subgraph, it is not a good idea to continually upgrade it and front the upgrade costs. Maintaining a stable and consistent version of your subgraph is critical, not only from the cost perspective but also so that Indexers can feel confident in their syncing times. Indexers should be flagged when you plan for an upgrade so that Indexer syncing times do not get impacted. Feel free to leverage the [#Indexers channel](https://discord.gg/rC8rBuRtbH) on Discord to let Indexers know when you're versioning your subgraphs.
+If you're making a lot of changes to your subgraph, it is not a good idea to continually update it and front the update costs. Maintaining a stable and consistent version of your subgraph is critical, not only from the cost perspective but also so that Indexers can feel confident in their syncing times. Indexers should be flagged when you plan for an update so that Indexer syncing times do not get impacted. Feel free to leverage the [#Indexers channel](https://discord.gg/rC8rBuRtbH) on Discord to let Indexers know when you're versioning your subgraphs.
 
 Subgraphs are open APIs that external developers are leveraging. Open APIs need to follow strict standards so that they do not break external developers' applications. In The Graph Network, a subgraph developer must consider Indexers and how long it takes them to sync a new subgraph **as well as** other developers who are using their subgraphs.
 
@@ -194,7 +194,7 @@ Follow the steps [here](/managing/deprecating-a-subgraph) to deprecate your subg
 
 ## Querying a Subgraph + Billing on The Graph Network
 
-The Hosted Service was set up to allow developers to deploy their subgraphs without any restrictions.
+The hosted service was set up to allow developers to deploy their subgraphs without any restrictions.
 
 In order for The Graph Network to truly be decentralized, query fees have to be paid as a core part of the protocol's incentives. For more information on subscribing to APIs and paying the query fees, check out billing documentation [here](/billing/).
 
@@ -210,7 +210,7 @@ Remember that it's a dynamic and growing market, but how you interact with it is
 
 ## Additional Resources
 
-If you're still confused, fear not! Check out the following resources or watch our video guide on migrating subgraphs to the decentralized network below:
+If you're still confused, fear not! Check out the following resources or watch our video guide on upgrading subgraphs to the decentralized network below:
 
 <VideoEmbed youtube="CzdQ3dFFrjo" />
 

--- a/website/pages/en/cookbook/upgrading-a-subgraph.mdx
+++ b/website/pages/en/cookbook/upgrading-a-subgraph.mdx
@@ -6,7 +6,7 @@ title: Upgrading an Existing Subgraph to The Graph Network
 
 This is a guide on how to upgrade your subgraph from the hosted service to The Graph's decentralized network. Upgrading to The Graph Network has been successful for projects like Opyn, UMA, mStable, Audius, PoolTogether, Livepeer, RAI, Enzyme, DODO, Pickle, and BadgerDAO all of which are relying on data served by Indexers on the network. There are now over 700 subgraphs live on The Graph's decentralized network, generating query fees and actively indexing web3 data.
 
-The process of Upgrading is quick and your subgraphs will forever benefit from the reliability and performance that you can only get on The Graph Network.
+The process of upgrading is quick and your subgraphs will forever benefit from the reliability and performance that you can only get on The Graph Network.
 
 ### Assumptions
 

--- a/website/pages/en/cookbook/upgrading-a-subgraph.mdx
+++ b/website/pages/en/cookbook/upgrading-a-subgraph.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrade an Existing Subgraph to The Graph Network
+title: Upgrading an Existing Subgraph to The Graph Network
 ---
 
 ## Introduction

--- a/website/pages/en/deploying/hosted-service.mdx
+++ b/website/pages/en/deploying/hosted-service.mdx
@@ -2,7 +2,7 @@
 title: What is the Hosted Service?
 ---
 
-> Please note, the hosted service will begin sunsetting in 2023, but it will remain available to networks that are not supported on the decentralized network. Developers are encouraged to [upgrade their subgraphs](/cookbook/upgrading-a-subgraph) as more networks are supported. Each network will have their hosted service equivalents gradually sunset to ensure developers have enough time to upgrade subgraphs to the decentralized network. Read more about the sunsetting of the hosted service [here](https://thegraph.com/blog/sunsetting-hosted-service).
+> Please note, the hosted service will begin sunsetting in 2023, but it will remain available to networks that are not supported on the decentralized network. Developers are encouraged to [upgrade their subgraphs to The Graph Network](/cookbook/upgrading-a-subgraph) as more networks are supported. Each network will have their hosted service equivalents gradually sunset to ensure developers have enough time to upgrade subgraphs to the decentralized network. Read more about the sunsetting of the hosted service [here](https://thegraph.com/blog/sunsetting-hosted-service).
 
 This section will walk you through deploying a subgraph to the [hosted service](https://thegraph.com/hosted-service/).
 

--- a/website/pages/en/deploying/hosted-service.mdx
+++ b/website/pages/en/deploying/hosted-service.mdx
@@ -2,11 +2,11 @@
 title: What is the Hosted Service?
 ---
 
-> Please note, the Hosted Service will begin sunsetting in Q1 2023, but it will remain available to networks that are not supported on the decentralized network. Developers are encouraged to [migrate their subgraphs](https://thegraph.com/blog/how-to-migrate-ethereum-subgraph) as more networks are supported. Each network will have their hosted service equivalents gradually sunset to ensure developers have enough time to migrate subgraphs to the decentralized network. Read more about the sunsetting of the Hosted Service [here](https://thegraph.com/blog/sunsetting-hosted-service).
+> Please note, the hosted service will begin sunsetting in 2023, but it will remain available to networks that are not supported on the decentralized network. Developers are encouraged to [upgrade their subgraphs](/cookbook/upgrading-a-subgraph) as more networks are supported. Each network will have their hosted service equivalents gradually sunset to ensure developers have enough time to upgrade subgraphs to the decentralized network. Read more about the sunsetting of the hosted service [here](https://thegraph.com/blog/sunsetting-hosted-service).
 
-This section will walk you through deploying a subgraph to the [Hosted Service](https://thegraph.com/hosted-service/).
+This section will walk you through deploying a subgraph to the [hosted service](https://thegraph.com/hosted-service/).
 
-If you don't have an account on the Hosted Service, you can sign up with your GitHub account. Once you authenticate, you can start creating subgraphs through the UI and deploying them from your terminal. The Hosted Service supports a number of networks, such as Polygon, Gnosis Chain, BNB Chain, Optimism, Arbitrum, and more.
+If you don't have an account on the hosted service, you can sign up with your GitHub account. Once you authenticate, you can start creating subgraphs through the UI and deploying them from your terminal. The hosted service supports a number of networks, such as Polygon, Gnosis Chain, BNB Chain, Optimism, Arbitrum, and more.
 
 For a comprehensive list, see [Supported Networks](/developing/supported-networks/#hosted-service).
 
@@ -16,7 +16,7 @@ First follow the instructions [here](/developing/defining-a-subgraph) to install
 
 ### From an Existing Contract
 
-If you already have a smart contract deployed to your network of choice, bootstrapping a new subgraph from this contract can be a good way to get started on the Hosted Service.
+If you already have a smart contract deployed to your network of choice, bootstrapping a new subgraph from this contract can be a good way to get started on the hosted service.
 
 You can use this command to create a subgraph that indexes all events from an existing contract. This will attempt to fetch the contract ABI from [Etherscan](https://etherscan.io/).
 
@@ -46,6 +46,6 @@ graph init --from-example --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 
 The example subgraph is based on the Gravity contract by Dani Grant that manages user avatars and emits `NewGravatar` or `UpdateGravatar` events whenever avatars are created or updated. The subgraph handles these events by writing `Gravatar` entities to the Graph Node store and ensuring these are updated according to the events. Continue on to the [subgraph manifest](/developing/creating-a-subgraph#the-subgraph-manifest) to better understand which events from your smart contracts to pay attention to, mappings, and more.
 
-## Supported Networks on the Hosted Service
+## Supported Networks on the hosted service
 
 You can find the list of the supported networks [Here](/developing/supported-networks).

--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -975,7 +975,7 @@ This is similar to the [existing data source templates](https://thegraph.com/doc
 
 > This replaces the existing `ipfs.cat` API
 
-### Migration guide
+### Upgrade guide
 
 #### Update `graph-ts` and `graph-cli`
 
@@ -1171,7 +1171,7 @@ Handlers for File Data Sources cannot be in files which import `eth_call` contra
 
 #### Examples
 
-[Crypto Coven Subgraph migration](https://github.com/azf20/cryptocoven-api/tree/file-data-sources-refactor)
+[Crypto Coven Subgraph upgrade](https://github.com/azf20/cryptocoven-api/tree/file-data-sources-refactor)
 
 #### References
 

--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -1171,7 +1171,7 @@ Handlers for File Data Sources cannot be in files which import `eth_call` contra
 
 #### Examples
 
-[Crypto Coven Subgraph upgrade](https://github.com/azf20/cryptocoven-api/tree/file-data-sources-refactor)
+[Crypto Coven Subgraph migration](https://github.com/azf20/cryptocoven-api/tree/file-data-sources-refactor)
 
 #### References
 

--- a/website/pages/en/developing/developer-faqs.mdx
+++ b/website/pages/en/developing/developer-faqs.mdx
@@ -137,6 +137,6 @@ The Graph will never charge for the hosted service. The Graph is a decentralized
 
 The hosted service will shut down in 2023. Read the announcement blog post [here](https://thegraph.com/blog/sunsetting-hosted-service). All dapps using the hosted service are encouraged to upgrade to the decentralized network. Network Grants are available for developers to help upgrade their subgraph to The Graph Network. If your dapp is upgrading a subgraph you can apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com).
 
-## 28. How do I update a subgraph on mainnet?
+## 28. How do I deploy a subgraph on mainnet?
 
 If you’re a subgraph developer, you can update a new version of your subgraph to the Subgraph Studio using the CLI. It’ll be private at that point, but if you’re happy with it, you can publish to the decentralized Graph Explorer. This will create a new version of your subgraph that Curators can start signaling on.

--- a/website/pages/en/developing/developer-faqs.mdx
+++ b/website/pages/en/developing/developer-faqs.mdx
@@ -135,8 +135,8 @@ The Graph will never charge for the hosted service. The Graph is a decentralized
 
 ## 27. When will the Hosted Service be shut down?
 
-The hosted service will shut down in 2023. Read the announcement blog post [here](https://thegraph.com/blog/sunsetting-hosted-service). All dapps using the hosted service are encouraged to upgrade to the decentralized network. Upgrade Grants are available for developers to help upgrade their subgraph. If your dapp is upgrading a subgraph you can apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com).
+The hosted service will shut down in 2023. Read the announcement blog post [here](https://thegraph.com/blog/sunsetting-hosted-service). All dapps using the hosted service are encouraged to upgrade to the decentralized network. Network Grants are available for developers to help upgrade their subgraph to The Graph Network. If your dapp is upgrading a subgraph you can apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com).
 
-## 28. How do I upgrade a subgraph on mainnet?
+## 28. How do I update a subgraph on mainnet?
 
-If you’re a subgraph developer, you can upgrade a new version of your subgraph to the Studio using the CLI. It’ll be private at that point, but if you’re happy with it, you can publish to the decentralized Graph Explorer. This will create a new version of your subgraph that Curators can start signaling on.
+If you’re a subgraph developer, you can update a new version of your subgraph to the Subgraph Studio using the CLI. It’ll be private at that point, but if you’re happy with it, you can publish to the decentralized Graph Explorer. This will create a new version of your subgraph that Curators can start signaling on.

--- a/website/pages/en/developing/developer-faqs.mdx
+++ b/website/pages/en/developing/developer-faqs.mdx
@@ -137,6 +137,6 @@ The Graph will never charge for the hosted service. The Graph is a decentralized
 
 The hosted service will shut down in 2023. Read the announcement blog post [here](https://thegraph.com/blog/sunsetting-hosted-service). All dapps using the hosted service are encouraged to upgrade to the decentralized network. Network Grants are available for developers to help upgrade their subgraph to The Graph Network. If your dapp is upgrading a subgraph you can apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com).
 
-## 28. How do I deploy a subgraph on mainnet?
+## 28. How do I update a subgraph on mainnet?
 
-If you’re a subgraph developer, you can update a new version of your subgraph to the Subgraph Studio using the CLI. It’ll be private at that point, but if you’re happy with it, you can publish to the decentralized Graph Explorer. This will create a new version of your subgraph that Curators can start signaling on.
+If you’re a subgraph developer, you can deploy a new version of your subgraph to the Subgraph Studio using the CLI. It’ll be private at that point, but if you’re happy with it, you can publish to the decentralized Graph Explorer. This will create a new version of your subgraph that Curators can start signaling on.

--- a/website/pages/en/developing/developer-faqs.mdx
+++ b/website/pages/en/developing/developer-faqs.mdx
@@ -127,15 +127,15 @@ Currently, the recommended approach for a dapp is to add the key to the frontend
 
 ## 25. Where do I go to find my current subgraph on the Hosted Service?
 
-Head over to the Hosted Service in order to find subgraphs that you or others deployed to the Hosted Service. You can find it [here](https://thegraph.com/hosted-service).
+Head over to the hosted service in order to find subgraphs that you or others deployed to the hosted service. You can find it [here](https://thegraph.com/hosted-service).
 
 ## 26. Will the Hosted Service start charging query fees?
 
-The Graph will never charge for the Hosted Service. The Graph is a decentralized protocol, and charging for a centralized service is not aligned with The Graph’s values. The Hosted Service was always a temporary step to help get to the decentralized network. Developers will have a sufficient amount of time to migrate to the decentralized network as they are comfortable.
+The Graph will never charge for the hosted service. The Graph is a decentralized protocol, and charging for a centralized service is not aligned with The Graph’s values. The hosted service was always a temporary step to help get to the decentralized network. Developers will have a sufficient amount of time to upgrade to the decentralized network as they are comfortable.
 
 ## 27. When will the Hosted Service be shut down?
 
-The Hosted Service will shut down in Q1 2023. Read the announcement blog post [here](https://thegraph.com/blog/sunsetting-hosted-service). All dapps using the Hosted Service are encouraged to migrate to the decentralized network. Migration Grants are available for developers to help migrate their subgraph. If your dapp is migrating a subgraph you can apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com).
+The hosted service will shut down in 2023. Read the announcement blog post [here](https://thegraph.com/blog/sunsetting-hosted-service). All dapps using the hosted service are encouraged to upgrade to the decentralized network. Upgrade Grants are available for developers to help upgrade their subgraph. If your dapp is upgrading a subgraph you can apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com).
 
 ## 28. How do I upgrade a subgraph on mainnet?
 

--- a/website/pages/en/glossary.mdx
+++ b/website/pages/en/glossary.mdx
@@ -84,6 +84,6 @@ title: Glossary
 
 - **_Upgrading_ a subgraph to The Graph Network**: The process of moving a subgraph from the hosted service to The Graph Network.
 
-- **_Updating_ a subgraph**: The process of updating a subgraph's schema and/or mappings, resulting in a new subgraph version.
+- **_Updating_ a subgraph**: The process of releasing a new subgraph version with updates to the subgraph's manifest, schema, or mappings.
 
 - **Migrating**: The process of curation shares moving from an old version of a subgraph to a new version of a subgraph (i.e., curation shares move to the latest version when v0.0.1 is updated to v0.0.2).

--- a/website/pages/en/glossary.mdx
+++ b/website/pages/en/glossary.mdx
@@ -82,6 +82,6 @@ title: Glossary
 
 - **L2 Transfer Tools**: Smart contracts and UI that enable network participants to transfer from Ethereum mainnet to Arbitrum One. Network participants can transfer delegated GRT, subgraphs, curation shares, and Indexer's self stake.
 
-- **"Updgrading" a subgraph to The Graph Network**: The process of moving a subgraph from the hosted service to The Graph Network.
+- **"Upgrading" a subgraph to The Graph Network**: The process of moving a subgraph from the hosted service to The Graph Network.
 
 - **"Updating" a subgraph**: The process of updating a subgraph's schema and/or mappings, resulting in a new subgraph version.

--- a/website/pages/en/glossary.mdx
+++ b/website/pages/en/glossary.mdx
@@ -82,6 +82,6 @@ title: Glossary
 
 - **L2 Transfer Tools**: Smart contracts and UI that enable network participants to transfer from Ethereum mainnet to Arbitrum One. Network participants can transfer delegated GRT, subgraphs, curation shares, and Indexer's self stake.
 
-- **"Updgrading" a subgraph**:
+- **"Updgrading" a subgraph to The Graph Network**: The process of moving a subgraph from the hosted service to The Graph Network.
 
-- **"Updating" a subgraph**:
+- **"Updating" a subgraph**: The process of updating a subgraph's schema and/or mappings, resulting in a new subgraph version.

--- a/website/pages/en/glossary.mdx
+++ b/website/pages/en/glossary.mdx
@@ -82,6 +82,6 @@ title: Glossary
 
 - **L2 Transfer Tools**: Smart contracts and UI that enable network participants to transfer from Ethereum mainnet to Arbitrum One. Network participants can transfer delegated GRT, subgraphs, curation shares, and Indexer's self stake.
 
-- **"Upgrading" a subgraph to The Graph Network**: The process of moving a subgraph from the hosted service to The Graph Network.
+- **_Upgrading_ a subgraph to The Graph Network**: The process of moving a subgraph from the hosted service to The Graph Network.
 
-- **"Updating" a subgraph**: The process of updating a subgraph's schema and/or mappings, resulting in a new subgraph version.
+- **_Updating_ a subgraph**: The process of updating a subgraph's schema and/or mappings, resulting in a new subgraph version.

--- a/website/pages/en/glossary.mdx
+++ b/website/pages/en/glossary.mdx
@@ -81,3 +81,7 @@ title: Glossary
 - **Cooldown Period**: The time remaining until an Indexer who changed their delegation parameters can do so again.
 
 - **L2 Transfer Tools**: Smart contracts and UI that enable network participants to transfer from Ethereum mainnet to Arbitrum One. Network participants can transfer delegated GRT, subgraphs, curation shares, and Indexer's self stake.
+
+- **"Updgrading" a subgraph**:
+
+- **"Updating" a subgraph**:

--- a/website/pages/en/glossary.mdx
+++ b/website/pages/en/glossary.mdx
@@ -85,3 +85,5 @@ title: Glossary
 - **_Upgrading_ a subgraph to The Graph Network**: The process of moving a subgraph from the hosted service to The Graph Network.
 
 - **_Updating_ a subgraph**: The process of updating a subgraph's schema and/or mappings, resulting in a new subgraph version.
+
+- **Migrating**: The process of curation shares moving from an old version of a subgraph to a new version of a subgraph (i.e., curation shares move to the latest version when v0.0.1 is updated to v0.0.2).

--- a/website/pages/en/mips-faqs.mdx
+++ b/website/pages/en/mips-faqs.mdx
@@ -10,7 +10,7 @@ To support the sunsetting of the hosted service and the migration of all of it's
 
 The MIPs program is an incentivization program for Indexers to support them with resources to index chains beyond Ethereum mainnet and help The Graph protocol expand the decentralized network into a multi-chain infrastructure layer.
 
-The MIPs program has allocated 0.75% of the GRT supply (75M GRT), with 0.5% to reward Indexers who contribute to bootstrapping the network and 0.25% allocated to migration grants for subgraph developers using multi-chain subgraphs.
+The MIPs program has allocated 0.75% of the GRT supply (75M GRT), with 0.5% to reward Indexers who contribute to bootstrapping the network and 0.25% allocated to network grants for subgraph developers using multi-chain subgraphs.
 
 ### Useful Resources
 

--- a/website/pages/en/mips-faqs.mdx
+++ b/website/pages/en/mips-faqs.mdx
@@ -10,7 +10,7 @@ To support the sunsetting of the hosted service and the migration of all of it's
 
 The MIPs program is an incentivization program for Indexers to support them with resources to index chains beyond Ethereum mainnet and help The Graph protocol expand the decentralized network into a multi-chain infrastructure layer.
 
-The MIPs program has allocated 0.75% of the GRT supply (75M GRT), with 0.5% to reward Indexers who contribute to bootstrapping the network and 0.25% allocated to network grants for subgraph developers using multi-chain subgraphs.
+The MIPs program has allocated 0.75% of the GRT supply (75M GRT), with 0.5% to reward Indexers who contribute to bootstrapping the network and 0.25% allocated to Network Grants for subgraph developers using multi-chain subgraphs.
 
 ### Useful Resources
 

--- a/website/pages/en/network-transition-faq.mdx
+++ b/website/pages/en/network-transition-faq.mdx
@@ -24,15 +24,15 @@ The three distinct phases of hosted service deprecation for each network are:
 
 #### Phase 1 (The Sunray): Disable new subgraph creation for blockchains that have quality parity on the network
 
-In this stage, developers will no longer be able to deploy new subgraphs to the hosted service for that network. Developers will still be able to upgrade existing subgraphs on the hosted service.
+In this stage, developers will no longer be able to deploy new subgraphs to the hosted service for that network. Developers will still be able to update existing subgraphs on the hosted service.
 
 No network has yet begun Phase 1 of transitioning from the hosted service to the decentralized network.
 
 As networks enter Phase 1, please note that developers can still use the rate limited Developer Preview URL in the Subgraph Studio to develop and test their subgraphs (up to 1,000 free queries) without acquiring GRT or interacting with protocol economics.
 
-#### Phase 2 (The Sunbeam): Disable subgraph upgrades
+#### Phase 2 (The Sunbeam): Disable subgraph updates
 
-In this phase, upgrades to subgraphs must be made through Subgraph Studio and subsequently published to the decentralized network. Hosted service subgraphs for networks in this phase will still exist and will be queryable, but upgrades to subgraphs must be made on The Graph's decentralized network.
+In this phase, updates to subgraphs must be made through Subgraph Studio and subsequently published to the decentralized network. Hosted service subgraphs for networks in this phase will still exist and will be queryable, but updates to subgraphs must be made on The Graph's decentralized network.
 
 There are no exact timelines for when any network will move to this phase, as the process is driven by exit criteria surrounding core functionality, not dates.
 
@@ -84,7 +84,7 @@ The table below illustrates where each network is in the network integration pro
 
 > This table will not include test networks, which remain free in [Subgraph Studio](https://thegraph.com/studio/).
 
-| Network | Announcing integration on The Graph Network | Network Integration complete | Phase 1: disable new subgraphs on hosted service | Phase 2: disable subgraph upgrades on hosted service | Phase 3: disable subgraphs on hosted service |
+| Network | Announcing integration on The Graph Network | Network Integration complete | Phase 1: disable new subgraphs on hosted service | Phase 2: disable subgraph updates on hosted service | Phase 3: disable subgraphs on hosted service |
 | --- | :-: | :-: | :-: | :-: | :-: |
 | Ethereum | ✓ | ✓ |  |  |  |
 | Gnosis (formerly xDAI) | ✓ | ✓\* |  |  |  |
@@ -205,9 +205,9 @@ The gateway process queries so Indexers can serve dapps. The gateways are in an 
 
 ## Using The Network FAQs
 
-### Is there a cost to upgrade my subgraph?
+### Is there a cost to update my subgraph?
 
-Yes, it is 1% of curation signaled. The 1% is split evenly between Curators (0.5%) and subgraph developers (0.5%). So, for every 10K GRT signaled, it costs subgraph developers 50 GRT to upgrade.
+Yes, it is 1% of curation signaled. The 1% is split evenly between Curators (0.5%) and subgraph developers (0.5%). So, for every 10K GRT signaled, it costs subgraph developers 50 GRT to update.
 
 ### How do I speed up sync time?
 

--- a/website/pages/en/network-transition-faq.mdx
+++ b/website/pages/en/network-transition-faq.mdx
@@ -139,13 +139,13 @@ A max query budget of $0.0004 is recommended to maintain low average query price
 
 Learn how to migrate your subgraph to The Graph Network with this simple [step-by-step guide](https://thegraph.com/blog/how-to-migrate-ethereum-subgraph) or [this video](https://www.youtube.com/watch?v=syXwYEk-VnU&t=1s).
 
-### Are there migration grants for subgraphs that migrate early to The Graph Network?
+### Are there Network Grants for subgraphs that migrate early to The Graph Network?
 
-Yes. To apply for a grant, reach out [here](mailto:migration@thegraph.foundation).
+Yes. To apply for a Network Grant, reach out [here](mailto:migration@thegraph.foundation).
 
 ### Is there any financial/technical/marketing support through the migration process from The Graph ecosystem?
 
-There are migration grants for projects to use to curate subgraphs (to attract Indexers) and pay for initial query fees (apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com)), a [direct channel](http://thegraph.com/discord) to engineers to help every step of the way, and prioritized marketing campaigns to showcase your project after migration, exampled in these Twitter threads: [1](https://twitter.com/graphprotocol/status/1496891582401814537), [2](https://twitter.com/graphprotocol/status/1491926128302379008), & [3](https://twitter.com/graphprotocol/status/1491126245396201473).
+There are Network Grants for projects to use to curate subgraphs (to attract Indexers) and pay for initial query fees (apply [here](https://thegraph.typeform.com/to/Zz8UAPri?typeform-source=thegraph.com)), a [direct channel](http://thegraph.com/discord) to engineers to help every step of the way, and prioritized marketing campaigns to showcase your project after migration, exampled in these Twitter threads: [1](https://twitter.com/graphprotocol/status/1496891582401814537), [2](https://twitter.com/graphprotocol/status/1491926128302379008), & [3](https://twitter.com/graphprotocol/status/1491126245396201473).
 
 ### How long do queries take?
 
@@ -167,7 +167,7 @@ While there is still work to do, the aim is to offer comparable if not better qu
 
 It is recommended to curate with at least 10,000 GRT, which users can do in the same transaction as when they publish. Users can also ask the curation community to curate their subgraph [here](https://t.me/CurationStation).
 
-There are migration grants for the early migrants to cover these initial costs. Feel free to apply [here](mailto:migration@thegraph.foundation).
+There are Network Grants for the early migrants to cover these initial costs. Feel free to apply [here](mailto:migration@thegraph.foundation).
 
 ### Why does a subgraph need curation signal? What if there isn't enough signal on my subgraph from curators?
 

--- a/website/pages/en/network/benefits.mdx
+++ b/website/pages/en/network/benefits.mdx
@@ -91,4 +91,4 @@ The Graph’s decentralized network gives users access to geographic redundancy 
 
 Bottom line: The Graph Network is less expensive, easier to use, and produces superior results compared to running a `graph-node` locally.
 
-Start using The Graph Network today, and learn how to [migrate or deploy your subgraph](https://thegraph.com/blog/how-to-migrate-ethereum-subgraph).
+Start using The Graph Network today, and learn how to [upgrade or deploy your subgraph](/cookbook/upgrading-a-subgraph).

--- a/website/pages/en/network/benefits.mdx
+++ b/website/pages/en/network/benefits.mdx
@@ -79,7 +79,7 @@ Estimated costs are only for Ethereum Mainnet subgraphs — costs are even highe
 
 Curating signal on a subgraph is an optional one-time, net-zero cost (e.g., $1k in signal can be curated on a subgraph, and later withdrawn—with potential to earn returns in the process).
 
-Some users may need to update their subgraph to a new version. Due to Ethereum gas fees, upgrades cost ~$50 per update at time of writing.
+Some users may need to update their subgraph to a new version. Due to Ethereum gas fees, an update costs ~$50 at time of writing.
 
 ## No Setup Costs & Greater Operational Efficiency
 

--- a/website/pages/en/network/benefits.mdx
+++ b/website/pages/en/network/benefits.mdx
@@ -81,6 +81,8 @@ Curating signal on a subgraph is an optional one-time, net-zero cost (e.g., $1k 
 
 Some users may need to update their subgraph to a new version. Due to Ethereum gas fees, an update costs ~$50 at time of writing.
 
+Note that gas fees on [Arbitrum](/arbitrum/arbitrum-faq) are substantially lower than Ethereum mainnet.
+
 ## No Setup Costs & Greater Operational Efficiency
 
 Zero setup fees. Get started immediately with no setup or overhead costs. No hardware requirements. No outages due to centralized infrastructure, and more time to concentrate on your core product . No need for backup servers, troubleshooting, or expensive engineering resources.

--- a/website/pages/en/network/benefits.mdx
+++ b/website/pages/en/network/benefits.mdx
@@ -79,7 +79,7 @@ Estimated costs are only for Ethereum Mainnet subgraphs — costs are even highe
 
 Curating signal on a subgraph is an optional one-time, net-zero cost (e.g., $1k in signal can be curated on a subgraph, and later withdrawn—with potential to earn returns in the process).
 
-Some users may need to upgrade subgraphs. Due to Ethereum gas fees, upgrades cost ~$50 per upgrade at time of this writing.
+Some users may need to update their subgraph to a new version. Due to Ethereum gas fees, upgrades cost ~$50 per update at time of writing.
 
 ## No Setup Costs & Greater Operational Efficiency
 
@@ -91,4 +91,4 @@ The Graph’s decentralized network gives users access to geographic redundancy 
 
 Bottom line: The Graph Network is less expensive, easier to use, and produces superior results compared to running a `graph-node` locally.
 
-Start using The Graph Network today, and learn how to [upgrade or deploy your subgraph](/cookbook/upgrading-a-subgraph).
+Start using The Graph Network today, and learn how to [upgrade your subgraph to The Graph's decentralized network](/cookbook/upgrading-a-subgraph).

--- a/website/pages/en/network/curating.mdx
+++ b/website/pages/en/network/curating.mdx
@@ -4,7 +4,7 @@ title: Curating
 
 Curators are critical to the Graph decentralized economy. They use their knowledge of the web3 ecosystem to assess and signal on the subgraphs that should be indexed by The Graph Network. Through the Explorer, curators are able to view network data to make signaling decisions. The Graph Network rewards curators who signal on good quality subgraphs with a share of the query fees that subgraphs generate. Curators are economically incentivized to signal early. These cues from curators are important for Indexers, who can then process or index the data from these signaled subgraphs.
 
-When signaling, curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. When signaling using auto-migrate, a curator’s shares will always be upgraded to the latest version published by the developer. If you decide to signal on a specific version instead, shares will always stay on this specific version.
+When signaling, curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. When signaling using auto-migrate, a Curator’s shares will always be updated to the latest version published by the developer. If you decide to signal on a specific version instead, shares will always stay on this specific version.
 
 Remember that curation is risky. Please do your diligence to make sure you curate on subgraphs you trust. Creating a subgraph is permissionless, so people can create subgraphs and call them any name they'd like. For more guidance on curation risks, check out [The Graph Academy's Curation Guide.](https://thegraph.academy/curators/)
 
@@ -79,13 +79,13 @@ Finding high-quality subgraphs is a complex task, but it can be approached in ma
 - Curators can use their understanding of a network to try and predict how an individual subgraph may generate a higher or lower query volume in the future
 - Curators should also understand the metrics that are available through The Graph Explorer. Metrics like past query volume and who the subgraph developer is can help determine whether or not a subgraph is worth signalling on.
 
-### 3. What’s the cost of upgrading a subgraph?
+### 3. What’s the cost of updating a subgraph?
 
-Migrating your curation shares to a new subgraph version incurs a curation tax of 1%. Curators can choose to subscribe to the newest version of a subgraph. When curator shares get auto-migrated to a new version, Curators will also pay half curation tax, ie. 0.5%, because upgrading subgraphs is an on-chain action that costs gas.
+Migrating your curation shares to a new subgraph version incurs a curation tax of 1%. Curators can choose to subscribe to the newest version of a subgraph. When curator shares get auto-migrated to a new version, Curators will also pay half curation tax, ie. 0.5%, because updating subgraphs is an on-chain action that costs gas.
 
-### 4. How often can I upgrade my subgraph?
+### 4. How often can I updating my subgraph?
 
-It’s suggested that you don’t upgrade your subgraphs too frequently. See the question above for more details.
+It’s suggested that you don’t updating your subgraphs too frequently. See the question above for more details.
 
 ### 5. Can I sell my curation shares?
 

--- a/website/pages/en/network/curating.mdx
+++ b/website/pages/en/network/curating.mdx
@@ -4,7 +4,7 @@ title: Curating
 
 Curators are critical to the Graph decentralized economy. They use their knowledge of the web3 ecosystem to assess and signal on the subgraphs that should be indexed by The Graph Network. Through the Explorer, curators are able to view network data to make signaling decisions. The Graph Network rewards curators who signal on good quality subgraphs with a share of the query fees that subgraphs generate. Curators are economically incentivized to signal early. These cues from curators are important for Indexers, who can then process or index the data from these signaled subgraphs.
 
-When signaling, curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. When signaling using auto-migrate, a Curator’s shares will always be updated to the latest version published by the developer. If you decide to signal on a specific version instead, shares will always stay on this specific version.
+When signaling, curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. When signaling using auto-migrate, a Curator’s shares will always be migrated to the latest version published by the developer. If you decide to signal on a specific version instead, shares will always stay on this specific version.
 
 Remember that curation is risky. Please do your diligence to make sure you curate on subgraphs you trust. Creating a subgraph is permissionless, so people can create subgraphs and call them any name they'd like. For more guidance on curation risks, check out [The Graph Academy's Curation Guide.](https://thegraph.academy/curators/)
 

--- a/website/pages/en/network/curating.mdx
+++ b/website/pages/en/network/curating.mdx
@@ -83,7 +83,7 @@ Finding high-quality subgraphs is a complex task, but it can be approached in ma
 
 Migrating your curation shares to a new subgraph version incurs a curation tax of 1%. Curators can choose to subscribe to the newest version of a subgraph. When curator shares get auto-migrated to a new version, Curators will also pay half curation tax, ie. 0.5%, because updating subgraphs is an on-chain action that costs gas.
 
-### 4. How often can I updating my subgraph?
+### 4. How often can I update my subgraph?
 
 It’s suggested that you don’t updating your subgraphs too frequently. See the question above for more details.
 

--- a/website/pages/en/network/curating.mdx
+++ b/website/pages/en/network/curating.mdx
@@ -60,7 +60,7 @@ Indexers can find subgraphs to index based on curation signals they see in The G
 ## Risks
 
 1. The query market is inherently young at The Graph and there is risk that your %APY may be lower than you expect due to nascent market dynamics.
-2. Curation Fee - when a curator signals GRT on a subgraph, they incur a 1% curation tax. This fee is burned and the rest is deposited into the reserve supply of the bonding curve.
+2. Curation Fee - when a Curator signals GRT on a subgraph, they incur a 1% curation tax. This fee is burned and the rest is deposited into the reserve supply of the bonding curve.
 3. When curators burn their shares to withdraw GRT, the GRT valuation of the remaining shares will be reduced. Be aware that in some cases, curators may decide to burn their shares **all at once**. This situation may be common if a dApp developer stops versioning/improving and querying their subgraph or if a subgraph fails. As a result, remaining curators might only be able to withdraw a fraction of their initial GRT. For a network role with a lower risk profile, see [Delegators](/network/delegating).
 4. A subgraph can fail due to a bug. A failed subgraph does not accrue query fees. As a result, you’ll have to wait until the developer fixes the bug and deploys a new version.
    - If you are subscribed to the newest version of a subgraph, your shares will auto-migrate to that new version. This will incur a 0.5% curation tax.
@@ -81,7 +81,7 @@ Finding high-quality subgraphs is a complex task, but it can be approached in ma
 
 ### 3. What’s the cost of updating a subgraph?
 
-Migrating your curation shares to a new subgraph version incurs a curation tax of 1%. Curators can choose to subscribe to the newest version of a subgraph. When curator shares get auto-migrated to a new version, Curators will also pay half curation tax, ie. 0.5%, because updating subgraphs is an on-chain action that costs gas.
+Migrating your curation shares to a new subgraph version incurs a curation tax of 1%. Curators can choose to subscribe to the newest version of a subgraph. When curation shares get auto-migrated to a new version, Curators will also pay half curation tax, ie. 0.5%, because updating subgraphs is an on-chain action that costs gas.
 
 ### 4. How often can I update my subgraph?
 

--- a/website/pages/en/network/curating.mdx
+++ b/website/pages/en/network/curating.mdx
@@ -85,7 +85,7 @@ Migrating your curation shares to a new subgraph version incurs a curation tax o
 
 ### 4. How often can I update my subgraph?
 
-It’s suggested that you don’t updating your subgraphs too frequently. See the question above for more details.
+It’s suggested that you don’t update your subgraphs too frequently. See the question above for more details.
 
 ### 5. Can I sell my curation shares?
 

--- a/website/pages/en/network/developing.mdx
+++ b/website/pages/en/network/developing.mdx
@@ -34,7 +34,7 @@ In order to make queries, developers must generate an API key, which can be done
 
 Developers are also able to express an Indexer preference to the gateway, for example preferring Indexers whose query response is faster, or whose data is most up to date. These controls are set in the Subgraph Studio.
 
-### Upgrading Subgraphs
+### Updating Subgraphs
 
 After a time a subgraph developer may want to update their subgraph, perhaps fixing a bug or adding new functionality. The subgraph developer may deploy new version(s) of their subgraph to the Subgraph Studio for rate-limited development and testing.
 

--- a/website/pages/en/network/developing.mdx
+++ b/website/pages/en/network/developing.mdx
@@ -38,7 +38,7 @@ Developers are also able to express an Indexer preference to the gateway, for ex
 
 After a time a subgraph developer may want to update their subgraph, perhaps fixing a bug or adding new functionality. The subgraph developer may deploy new version(s) of their subgraph to the Subgraph Studio for rate-limited development and testing.
 
-Once the Subgraph Developer is ready to upgrade, they can initiate a transaction to point their subgraph at the new version. Upgrading the subgraph migrates any signal to the new version (assuming the user who applied the signal selected "auto-migrate"), which also incurs a migration tax. This signal migration should prompt Indexers to start indexing the new version of the subgraph, so it should soon become available for querying.
+Once the Subgraph Developer is ready to update, they can initiate a transaction to point their subgraph at the new version. Updating the subgraph migrates any signal to the new version (assuming the user who applied the signal selected "auto-migrate"), which also incurs a migration tax. This signal migration should prompt Indexers to start indexing the new version of the subgraph, so it should soon become available for querying.
 
 ### Deprecating Subgraphs
 
@@ -50,4 +50,4 @@ Some developers will engage with the full subgraph lifecycle on the network, pub
 
 ### Developers and Network Economics
 
-Developers are a key economic actor in the network, locking up GRT in order to encourage indexing, and crucially querying subgraphs, which is the network's primary value exchange. Subgraph developers also burn GRT whenever a subgraph is upgraded.
+Developers are a key economic actor in the network, locking up GRT in order to encourage indexing, and crucially querying subgraphs, which is the network's primary value exchange. Subgraph developers also burn GRT whenever a subgraph is updated.

--- a/website/remote-files/substreams.json
+++ b/website/remote-files/substreams.json
@@ -27,6 +27,7 @@
     "developers-guide/parallel-execution.md",
     "developers-guide/running-substreams.md",
     "developers-guide/sink-targets/README.md",
+    "developers-guide/sink-targets/substreams-powered-subgraph.md",
     "developers-guide/sink-targets/substreams-sink-clickhouse.md",
     "developers-guide/sink-targets/substreams-sink-files.md",
     "developers-guide/sink-targets/substreams-sink-kv.md",


### PR DESCRIPTION
- "Migrating" to the network is now "Upgrading" to the network
- Upgrade (previously used to refer to releasing a new version of a subgraph) is now "updating a subgraph"
- Migration grants are now "Network Grants"

Other misc. changes:
- Updated URL of migration cookbook (hopefully with a functional redirect)
- Added definitions to the glossary