### PR TITLE
Fix typo in assemblyscript-api.mdx

### DIFF
--- a/website/pages/en/developing/assemblyscript-api.mdx
+++ b/website/pages/en/developing/assemblyscript-api.mdx
@@ -176,7 +176,7 @@ import { TypedMap } from '@graphprotocol/graph-ts'
 
 The `TypedMap` class has the following API:
 
-- `new TypedMap<K, V>()` – creates an empty map with keys of type `K` and values of type `T`
+- `new TypedMap<K, V>()` – creates an empty map with keys of type `K` and values of type `V`
 - `map.set(key: K, value: V): void` – sets the value of `key` to `value`
 - `map.getEntry(key: K): TypedMapEntry<K, V> | null` – returns the key-value pair for a `key` or `null` if the `key` does not exist in the map
 - `map.get(key: K): V | null` – returns the value for a `key` or `null` if the `key` does not exist in the map


### PR DESCRIPTION
The type of values should be `V`, not `T`.