### PR TITLE
Fix links in remote content

### DIFF
--- a/website/pages/en/querying/graph-client/[[...slug]].mdx
+++ b/website/pages/en/querying/graph-client/[[...slug]].mdx
@@ -1,8 +1,9 @@
 import { RemoteContent } from 'nextra/data'
 import { buildDynamicMDX } from 'nextra/remote'
+import { getPageMap } from '@/src/getPageMap'
+import { remarkReplaceLinks } from '@/src/remarkReplaceLinks'
 import { Mermaid } from 'nextra/components'
 import { visit } from 'unist-util-visit'
-import { getPageMap } from '@/src/getPageMap'
 import json from '@/remote-files/graph-client.json'
 
 export const getStaticPaths = () => ({
@@ -20,9 +21,8 @@ export async function getStaticProps({ params }) {
   const foundPath = filePaths.find((filePath) => filePath.startsWith(paths))
   const baseURL = `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${docsPath}${foundPath}`
   const response = await fetch(baseURL)
-  const data = await response.text()
-  const mdx = await buildDynamicMDX(data, {
-    codeHighlight: false,
+  const content = await response.text()
+  const mdx = await buildDynamicMDX(content, {
     mdxOptions: {
       remarkPlugins: [
         () => (tree, _file, done) => {
@@ -33,8 +33,10 @@ export async function getStaticProps({ params }) {
           })
           done()
         },
+        [remarkReplaceLinks, { foundPath, basePath: '/querying/graph-client/' }],
       ],
     },
+    codeHighlight: false,
   })
   return {
     props: {

--- a/website/pages/en/substreams/[[...slug]].mdx
+++ b/website/pages/en/substreams/[[...slug]].mdx
@@ -24,8 +24,8 @@ export async function getStaticProps({ params }) {
   const content = await response.text()
   const mdx = await buildDynamicMDX(replaceGitBookContent({ content }), {
     mdxOptions: {
-      // change-log contains `{variable}` text that is thrown an error by MDX2 parser since he treats
-      // it as variable injection, to fix it we parse chang-log with the Markdown parser
+      // change-log contains `{variable}` text that is thrown an error by MDX2 parser since it treats
+      // it as variable injection, to fix it we parse `change-log` with the Markdown parser
       format: paths.endsWith('/change-log') ? 'md' : 'mdx',
       remarkPlugins: [
         [remarkReplaceLinks, { foundPath, basePath: '/substreams/' }],

--- a/website/src/remarkReplaceImages.ts
+++ b/website/src/remarkReplaceImages.ts
@@ -3,7 +3,7 @@ import { Plugin } from 'unified'
 import { visit } from 'unist-util-visit'
 
 export const remarkReplaceImages: Plugin<[{ assetsBasePath: string }], Root> = ({ assetsBasePath }) => {
-  if (!assetsBasePath) throw new Error('remarkReplaceLinks: assetsBasePath is required')
+  if (!assetsBasePath) throw new Error('remarkReplaceImages: assetsBasePath is required')
 
   return (tree, _file, done) => {
     visit(

--- a/website/src/remarkReplaceLinks.ts
+++ b/website/src/remarkReplaceLinks.ts
@@ -1,5 +1,6 @@
+import path from 'path'
+
 import { Root } from 'mdast'
-import path from 'node:path'
 import { Plugin } from 'unified'
 import { visit } from 'unist-util-visit'
 
@@ -22,7 +23,7 @@ export const remarkReplaceLinks: Plugin<[{ foundPath: string; basePath: string }
         node.url = node.url.replace('/', basePath)
       } else {
         // Relative to the current path, e.g. (foo)[bar] or (foo)[./bar] or (foo)[../bar]
-        node.url = path.join(path.dirname(foundPath), node.url)
+        node.url = path.join(basePath + path.dirname(foundPath), node.url)
       }
     })
     done()


### PR DESCRIPTION
This PR fixes some regressions around links in remote content introduced in #453 (which I found while testing on staging).

Some examples:
- On [this page](https://staging.thegraph.com/docs/en/substreams/developers-guide/installation-requirements/), `substreams CLI` links to `/en/substreams/developers-guide/installation-requirements/reference-and-specs/command-line-interface` (which is a 404)
  - With this PR, it correctly links to `/en/substreams/reference-and-specs/command-line-interface/`
- On [this page](https://staging.thegraph.com/docs/en/querying/graph-client/README/), `@live queries` links to `/en/querying/graph-client/README/live`
  - With this PR, it correctly links to `/en/querying/graph-client/live/`