### PR TITLE
removing the note on default api version, which was incorrect

### DIFF
--- a/website/pages/en/developing/assemblyscript-api.mdx
+++ b/website/pages/en/developing/assemblyscript-api.mdx
@@ -41,7 +41,7 @@ The `@graphprotocol/graph-ts` library provides the following APIs:
 
 ### Versions
 
-The `apiVersion` in the subgraph manifest specifies the mapping API version which is run by Graph Node for a given subgraph. The current mapping API version is 0.0.6.
+The `apiVersion` in the subgraph manifest specifies the mapping API version which is run by Graph Node for a given subgraph.
 
 | Version | Release notes |
 | :-: | --- |


### PR DESCRIPTION
Removing this from the docs as it is confusing and incorrect