### PR TITLE
Fix URL in quick start page

### DIFF
--- a/website/pages/en/cookbook/quick-start.mdx
+++ b/website/pages/en/cookbook/quick-start.mdx
@@ -161,4 +161,4 @@ Now, you can query your subgraph by sending GraphQL queries to your subgraph’s
 
 You can query from your dapp if you don't have your API key via the free, rate-limited temporary query URL that can be used for development and staging.
 
-For more information about querying data from your subgraph, read more [here](../querying/querying-the-graph/).
+For more information about querying data from your subgraph, read more [here](../../querying/querying-the-graph/).


### PR DESCRIPTION
The previous URL was broken.

This PR fixes it to point to:
https://thegraph.com/docs/en/cookbook/quick-start/