### PR TITLE
Fixes the specVersion required for polling filters

### DIFF
--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -810,7 +810,7 @@ dataSources:
 
 #### Polling Filter
 
-> **Requires `specVersion` >= 0.8.0**
+> **Requires `specVersion` >= 0.0.8**
 
 > **Note:** Polling filters are only available on dataSources of `kind: ethereum`.
 
@@ -826,7 +826,7 @@ The defined handler will be called once for every `n` blocks, where `n` is the v
 
 #### Once Filter
 
-> **Requires `specVersion` >= 0.8.0**
+> **Requires `specVersion` >= 0.0.8**
 
 > **Note:** Once filters are only available on dataSources of `kind: ethereum`.
 


### PR DESCRIPTION
It was mentioned as `0.8.0`, when it should be `0.0.8`