### PR TITLE
Fix redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -65,7 +65,7 @@ http {
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/developer/query-the-graph/$                   $scheme://$http_host/docs/$1/querying/querying-the-graph/                   permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/developer/querying-best-practices/$           $scheme://$http_host/docs/$1/querying/querying-best-practices/              permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/developer/querying-from-your-app/$            $scheme://$http_host/docs/$1/querying/querying-from-an-application/         permanent;
-        rewrite ^/docs/([a-zA-Z][a-zA-Z])/developer/quick-start/$                       $scheme://$http_host/docs/$1/cookbook/quick-start/                          permanent;
+        rewrite ^/docs/([a-zA-Z][a-zA-Z])/developer/quick-start/$                       $scheme://$http_host/docs/$1/quick-start/                                   permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/developer/subgraph-debug-forking/$            $scheme://$http_host/docs/$1/cookbook/subgraph-debug-forking/               permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/explorer/$                                    $scheme://$http_host/docs/$1/network/explorer/                              permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/hosted-service/deploy-subgraph-hosted/$       $scheme://$http_host/docs/$1/deploying/deploying-a-subgraph-to-hosted/      permanent;
@@ -87,9 +87,8 @@ http {
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/arbitrum-faq/$                                $scheme://$http_host/docs/$1/arbitrum/arbitrum-faq/                         permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/cookbook/migrating-a-subgraph/$               $scheme://$http_host/docs/$1/cookbook/upgrading-a-subgraph/                 permanent;
         rewrite ^/docs/([a-zA-Z][a-zA-Z])/cookbook/quick-start/$                        $scheme://$http_host/docs/$1/quick-start/                                   permanent;
-        rewrite ^/docs/en/substreams/(.+)$                                              https://substreams.streamingfast.io                                         permanent;
-        rewrite ^/docs/en/firehose/(.+)$                                                https://firehose.streamingfast.io                                           permanent;
-
+        rewrite ^/docs/en/substreams/(?!index\.).+$                                     https://substreams.streamingfast.io                                         permanent;
+        rewrite ^/docs/en/firehose/(?!index\.).+$                                       https://firehose.streamingfast.io                                           permanent;
 
         # Temporary redirects (302)
         rewrite ^/docs/en/querying/graph-client/$   $scheme://$http_host/docs/en/querying/graph-client/README/  redirect;

--- a/website/pages/en/cookbook/near.mdx
+++ b/website/pages/en/cookbook/near.mdx
@@ -277,7 +277,7 @@ Pending functionality is not yet supported for NEAR subgraphs. In the interim, y
 
 ### My question hasn't been answered, where can I get more help building NEAR subgraphs?
 
-If it is a general question about subgraph development, there is a lot more information in the rest of the [Developer documentation](/cookbook/quick-start). Otherwise please join [The Graph Protocol Discord](https://discord.gg/graphprotocol) and ask in the #near channel or email near@thegraph.com.
+If it is a general question about subgraph development, there is a lot more information in the rest of the [Developer documentation](/quick-start). Otherwise please join [The Graph Protocol Discord](https://discord.gg/graphprotocol) and ask in the #near channel or email near@thegraph.com.
 
 ## References
 

--- a/website/src/IndexPage.tsx
+++ b/website/src/IndexPage.tsx
@@ -27,7 +27,7 @@ export function Intro() {
         {
           title: t('index.shortcuts.quickStart.title'),
           description: t('index.shortcuts.quickStart.description'),
-          href: '/cookbook/quick-start',
+          href: '/quick-start',
         },
         {
           title: t('index.shortcuts.developerFaqs.title'),
@@ -47,7 +47,7 @@ export function Intro() {
         {
           title: t('index.shortcuts.migrateFromHostedService.title'),
           description: t('index.shortcuts.migrateFromHostedService.description'),
-          href: '/cookbook/migrating-a-subgraph',
+          href: '/cookbook/upgrading-a-subgraph',
         },
       ].map((card) => (
         <li key={card.href} sx={{ aspectRatio: '258/136' }}>


### PR DESCRIPTION
Annoyingly, the `^/docs/en/substreams/(.+)$` rewrite rule matched the `/docs/en/substreams/` path because the `index index.html index.htm` directive (which we need) results in an internal rewrite to `/docs/en/substreams/index.html`. This PR prevents that, in addition to some other redirect-related tweaks.