### PR TITLE
Choosing Russian translation for "subgraph"

### DIFF
--- a/website/pages/ru/index.json
+++ b/website/pages/ru/index.json
@@ -11,20 +11,20 @@
       "description": "Присоединяйтесь и начните работу с The Graph"
     },
     "developerFaqs": {
-      "title": "Часто задаваемы вопросы для разработчиков",
-      "description": "Часто задаваемы вопросы"
+      "title": "Часто задаваемые вопросы для разработчиков",
+      "description": "Часто задаваемые вопросы"
     },
     "queryFromAnApplication": {
       "title": "Запрос из приложения",
-      "description": "Узнайте как отправлять запросы из приложения"
+      "description": "Узнайте, как отправлять запросы из приложения"
     },
     "createASubgraph": {
       "title": "Создайте субграф",
-      "description": "Используйте Studio для создания субграфов"
+      "description": "Используйте Studio для создания подграфов"
     },
     "migrateFromHostedService": {
       "title": "Перенос из хостингового сервиса",
-      "description": "Перенос субграфов в сеть The Graph"
+      "description": "Перенос подграфов в сеть The Graph"
     }
   },
   "networkRoles": {
@@ -55,7 +55,7 @@
     "products": {
       "subgraphStudio": {
         "title": "Subgraph Studio",
-        "description": "Создание, управление и публикация субграфов и ключей API"
+        "description": "Создание, управление и публикация подграфов и ключей API"
       },
       "graphExplorer": {
         "title": "Graph Explorer",


### PR DESCRIPTION
I would recommend to choose one of the Russian translations of  "subgraph" - "субграф" or "подграф"  and keep it all across the docs. Because now you use both and it's a bit confusing, like when you use "subgraph" and "undergraph" at the same time in English. For me, "подграф" sounds better and it's easier to pronounce in Russian. Also fixed a typo.