### PR TITLE
Color Rust code snippets in substreams-powered subgraphs docs

### DIFF
--- a/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
+++ b/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
@@ -45,7 +45,7 @@ message Contract {
 
 The core logic of the Substreams package is a `map_contract` module in `lib.rs`, which processes every block, filtering for Create calls which did not revert, returning `Contracts`:
 
-```rs
+```rust
 #[substreams::handlers::map]
 fn map_contract(block: eth::v2::Block) -> Result<Contracts, substreams::errors::Error> {
     let contracts = block
@@ -71,7 +71,7 @@ A Substreams package can be used by a subgraph as long as it has a module which 
 
 > The `substreams_entity_change` crate also has a dedicated `Tables` function for simply generating entity changes ([documentation](https://docs.rs/substreams-entity-change/1.2.2/substreams_entity_change/tables/index.html)). The Entity Changes generated must be compatible with the `schema.graphql` entities defined in the `subgraph.graphql` of the corresponding subgraph.
 
-```rs
+```rust
 #[substreams::handlers::map]
 pub fn graph_out(contracts: Contracts) -> Result<EntityChanges, substreams::errors::Error> {
     // hash map of name to a table

--- a/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
+++ b/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
@@ -90,7 +90,7 @@ pub fn graph_out(contracts: Contracts) -> Result<EntityChanges, substreams::erro
 
 These types and modules are pulled together in `substreams.yaml`:
 
-```yml
+```yaml
 specVersion: v0.1.0
 package:
   name: 'substreams_test' # the name to be used in the .spkg

--- a/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
+++ b/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
@@ -8,7 +8,7 @@ title: Substreams-powered subgraphs
 
 This cookbook requires [yarn](https://yarnpkg.com/), [the dependencies necessary for local Substreams development](https://substreams.streamingfast.io/developers-guide/installation-requirements), and the latest version of Graph CLI (>=0.52.0):
 
-```
+```sh
 npm install -g @graphprotocol/graph-cli
 ```
 
@@ -16,7 +16,7 @@ npm install -g @graphprotocol/graph-cli
 
 > This cookbook uses this [Substreams-powered subgraph as a reference](https://github.com/graphprotocol/graph-tooling/tree/main/examples/substreams-powered-subgraph).
 
-```
+```sh
 graph init --from-example substreams-powered-subgraph
 ```
 
@@ -45,7 +45,7 @@ message Contract {
 
 The core logic of the Substreams package is a `map_contract` module in `lib.rs`, which processes every block, filtering for Create calls which did not revert, returning `Contracts`:
 
-```
+```rs
 #[substreams::handlers::map]
 fn map_contract(block: eth::v2::Block) -> Result<Contracts, substreams::errors::Error> {
     let contracts = block
@@ -71,7 +71,7 @@ A Substreams package can be used by a subgraph as long as it has a module which 
 
 > The `substreams_entity_change` crate also has a dedicated `Tables` function for simply generating entity changes ([documentation](https://docs.rs/substreams-entity-change/1.2.2/substreams_entity_change/tables/index.html)). The Entity Changes generated must be compatible with the `schema.graphql` entities defined in the `subgraph.graphql` of the corresponding subgraph.
 
-```
+```rs
 #[substreams::handlers::map]
 pub fn graph_out(contracts: Contracts) -> Result<EntityChanges, substreams::errors::Error> {
     // hash map of name to a table
@@ -90,7 +90,7 @@ pub fn graph_out(contracts: Contracts) -> Result<EntityChanges, substreams::erro
 
 These types and modules are pulled together in `substreams.yaml`:
 
-```
+```yml
 specVersion: v0.1.0
 package:
   name: 'substreams_test' # the name to be used in the .spkg


### PR DESCRIPTION
The docs [already](https://thegraph.com/docs/en/substreams/) contain colored Rust code snippets, so it would help reading if those would be colored too.