### PR TITLE
add a note on setting object references via context

### DIFF
--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -683,7 +683,7 @@ let tradingPair = context.getString('tradingPair')
 
 There are setters and getters like `setString` and `getString` for all value types.
 
-> **Note:** You can set object references in the context. Simply set the object id with `setBytes` and change the graphql schema accordingly. In the given ExchangeFactory example you might want to have a list of all NewExchange objects in the Factory.
+> **Note:** Referecing an entity is done via ID in graphQL. That id can be passed into the instantiated data source by setting it in the context and then accessed within the mapping of the template. Example can be found in the [documenation of graph-ts](https://github.com/graphprotocol/graph-tooling/tree/main/packages/ts#api).
 
 ## Start Blocks
 

--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -683,6 +683,8 @@ let tradingPair = context.getString('tradingPair')
 
 There are setters and getters like `setString` and `getString` for all value types.
 
+> **Note:** You can set object references in the context. Simply set the object id with `setBytes` and change the graphql schema accordingly. In the given ExchangeFactory example you might want to have a list of all NewExchange objects in the Factory.
+
 ## Start Blocks
 
 The `startBlock` is an optional setting that allows you to define from which block in the chain the data source will start indexing. Setting the start block allows the data source to skip potentially millions of blocks that are irrelevant. Typically, a subgraph developer will set `startBlock` to the block in which the smart contract of the data source was created.


### PR DESCRIPTION
In my subgraph I needed a reference between the factory and template. I ended up passing the factoryID to the template with context.