### PR TITLE
Workflow updates and fixes

### DIFF
--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout the repo
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,8 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v1

--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -15,11 +15,14 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout the repo
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+      - name: Set up env
+        uses: the-guild-org/shared-config/setup@main
+        with:
+          nodeVersion: 18
+          packageManager: pnpm
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout the repo
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -45,8 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v1

--- a/.github/workflows/next-js-bundle-analysis.yml
+++ b/.github/workflows/next-js-bundle-analysis.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout the repo
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-      - name: Setup env
+      - name: Set up env
         uses: the-guild-org/shared-config/setup@main
         with:
           nodeVersion: 18

--- a/.github/workflows/opengraph.yml
+++ b/.github/workflows/opengraph.yml
@@ -17,14 +17,14 @@ jobs:
     name: Deploy to Cloudflare Workers
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ env.COMMIT }}
 
-      - uses: the-guild-org/shared-config/setup@main
-        name: setup env
+      - name: Set up env
+        uses: the-guild-org/shared-config/setup@main
         with:
           nodeVersion: 18
           packageManager: pnpm

--- a/.github/workflows/website-integrity.yml
+++ b/.github/workflows/website-integrity.yml
@@ -14,12 +14,13 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
       - name: Fetch
         run: git fetch origin main
 
-      - name: Setup env
+      - name: Set up env
         uses: the-guild-org/shared-config/setup@main
         with:
           nodeVersion: 18

--- a/packages/og-image/package.json
+++ b/packages/og-image/package.json
@@ -19,7 +19,7 @@
     "@cloudflare/workers-types": "^4.20231025.0",
     "@types/react": "^18.2.34",
     "jest-image-snapshot": "^6.2.0",
-    "tsx": "^3.14.0",
+    "tsx": "^4.6.2",
     "typescript": "^5.2.2",
     "vitest": "^0.34.6",
     "wrangler": "^3.15.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       tsx:
-        specifier: ^3.14.0
-        version: 3.14.0
+        specifier: ^4.6.2
+        version: 4.6.2
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -219,8 +219,8 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2
       tsx:
-        specifier: ^3.14.0
-        version: 3.14.0
+        specifier: ^4.6.2
+        version: 4.6.2
       unified:
         specifier: ^11.0.4
         version: 11.0.4
@@ -11771,13 +11771,13 @@ packages:
       - ts-node
     dev: true
 
-  /tsx@3.14.0:
-    resolution: {integrity: sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==}
+  /tsx@4.6.2:
+    resolution: {integrity: sha512-QPpBdJo+ZDtqZgAnq86iY/PD2KYCUPSUGIunHdGwyII99GKH+f3z3FZ8XNFLSGQIA4I365ui8wnQpl8OKLqcsg==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
       esbuild: 0.18.20
       get-tsconfig: 4.7.2
-      source-map-support: 0.5.21
     optionalDependencies:
       fsevents: 2.3.3
     dev: true

--- a/website/package.json
+++ b/website/package.json
@@ -36,7 +36,7 @@
     "@types/react": "^18.2.34",
     "@types/react-dom": "^18.2.14",
     "fast-xml-parser": "^4.3.2",
-    "tsx": "^3.14.0",
+    "tsx": "^4.6.2",
     "unified": "^11.0.4"
   },
   "nextBundleAnalysis": {


### PR DESCRIPTION
This should fix the "Pull Request CI/CD" workflow failing in recent PRs, because it uses the latest LTS version of Node (20) which some of our stuff isn't yet compatible with.