### PR TITLE
docs: mention Int8 to represent i64

### DIFF
--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -254,6 +254,7 @@ We support the following scalars in our GraphQL API:
 | `String` | Scalar for `string` values. Null characters are not supported and are automatically removed. |
 | `Boolean` | Scalar for `boolean` values. |
 | `Int` | The GraphQL spec defines `Int` to have a size of 32 bytes. |
+| `Int8` | An 8-byte signed integer, also known as a 64-bit signed integer, can store values in the range from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807. Prefer using this to represent `i64` from ethereum. |
 | `BigInt` | Large integers. Used for Ethereum's `uint32`, `int64`, `uint64`, ..., `uint256` types. Note: Everything below `uint32`, such as `int32`, `uint24` or `int8` is represented as `i32`. |
 | `BigDecimal` | `BigDecimal` High precision decimals represented as a significand and an exponent. The exponent range is from −6143 to +6144. Rounded to 34 significant digits. |
 


### PR DESCRIPTION
Since `@graphprotocol/graph-cli@0.51.0` we can use `Int8` GraphQL Scalar type which is optimized for storage and is beneficial for most contracts that are indexing a `i64` in Solidity.

Closes #396

