### PR TITLE
ci: use latest image during prod deploy

### DIFF
--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -61,7 +61,7 @@ jobs:
           location: us-central1-a
 
       - name: Set a new k8s image and apply the manifests
-        run: .github/scripts/kustomize-apply.sh production $APP_NAME=$BASE_IMAGE:$GITHUB_SHA
+        run: .github/scripts/kustomize-apply.sh production $APP_NAME=$BASE_IMAGE:latest
 
       - name: Wait for pods to be ready
         run: .github/scripts/kubectl-wait-ready.sh $APP_NAME


### PR DESCRIPTION
instead of doing SHA based we just pull the `latest` this way we avoid any mixing of git tags and no need for empty commits to trigger a new image so we can rollout update. Anytime we run this job it will try to build latest from that state and use that fresh image.

