### PR TITLE
Update arbitrum-faq.mdx

### DIFF
--- a/website/pages/en/arbitrum/arbitrum-faq.mdx
+++ b/website/pages/en/arbitrum/arbitrum-faq.mdx
@@ -22,7 +22,7 @@ The Graph community decided to move forward with Arbitrum last year after the ou
 
 Users bridge their GRT and ETH  using one of the following methods:
 
-- [The Graph Bridge on Arbitrum](https://bridge.arbitrum.io/?l2ChainId=42161)
+- [The Arbitrum Bridge](https://bridge.arbitrum.io/?l2ChainId=42161)
 - [TransferTo](https://transferto.xyz/swap)
 - [Connext Bridge](https://bridge.connext.network/)
 - [Hop Exchange](https://app.hop.exchange/#/send?token=ETH)


### PR DESCRIPTION
Changed "The Graph Bridge on Arbitrum" with "The Arbitrum Bridge".

Seems misleading to use the term "The Graph Bridge"