### PR TITLE
docs: Developer FAQ - Question 10 corrected (Add multiple datasource on graph init command)

### DIFF
--- a/website/pages/en/developing/developer-faqs.mdx
+++ b/website/pages/en/developing/developer-faqs.mdx
@@ -50,7 +50,7 @@ Take a look at `Access to smart contract` state inside the section [AssemblyScri
 
 ## 10. Is it possible to set up a subgraph using `graph init` from `graph-cli` with two contracts? Or should I manually add another datasource in `subgraph.yaml` after running `graph init`?
 
-Unfortunately, this is currently not possible. `graph init` is intended as a basic starting point, from which you can then add more data sources manually.
+Yes. On `graph init` command itself you can add multiple datasources by entering contracts one after the other. You can also use `graph add` command to add new datasource.
 
 ## 11. I want to contribute or add a GitHub issue. Where can I find the open source repositories?
 


### PR DESCRIPTION
On `graph init` command, its now possible to add multiple datasources from `graph-cli` itself. We can also use `graph add` command to add new datasources. This info has not been updated on Question 10 in the FAQ section. 

References - [Link](https://github.com/graphprotocol/graph-tooling/tree/main/packages/cli)