### PR TITLE
Docs should specify `#` as comment symbol for GraphQL

### DIFF
--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -402,11 +402,11 @@ This more elaborate way of storing many-to-many relationships will result in les
 
 #### Adding comments to the schema
 
-As per GraphQL spec, comments can be added above schema entity attributes using double quotations `""`. This is illustrated in the example below:
+As per GraphQL spec, comments can be added above schema entity attributes using the hash symble `#`. This is illustrated in the example below:
 
 ```graphql
 type MyFirstEntity @entity {
-  "unique identifier and primary key of the entity"
+  # unique identifier and primary key of the entity
   id: Bytes!
   address: Bytes!
 }


### PR DESCRIPTION
Currently the graphprotocol docs specify double quotations `""` for comments in GraphQL.

According to the GraphQL spec, '#' are used for comments, not double quotes. See the GraphQL spec on comments here:

https://spec.graphql.org/October2021/#sec-Comments