### PR TITLE
Updated 'Subgraph Upgrade' video link to new video.

### DIFF
--- a/website/pages/en/cookbook/upgrading-a-subgraph.mdx
+++ b/website/pages/en/cookbook/upgrading-a-subgraph.mdx
@@ -14,7 +14,7 @@ The process of upgrading is quick and your subgraphs will forever benefit from t
 
 ## Upgrading an Existing Subgraph to The Graph Network
 
-<VideoEmbed youtube="MLqJdVCom5k" />
+<VideoEmbed youtube="hCmX5Dlhdjw" />
 
 If you are logged in to the hosted service, you can access a simple flow to upgrade your subgraphs from [your dashboard](https://thegraph.com/hosted-service/dashboard), or from an individual subgraph page.
 

--- a/website/pages/en/sunrise.mdx
+++ b/website/pages/en/sunrise.mdx
@@ -30,7 +30,7 @@ Yes, the upgrade Indexer will automatically support all hosted service subgraphs
 
 > Note: Upgrading a subgraph to The Graph Network cannot be undone.
 
-<VideoEmbed youtube="MLqJdVCom5k" />
+<VideoEmbed youtube="hCmX5Dlhdjw" />
 
 To upgrade a hosted service subgraph, you can visit the subgraph dashboard on the [hosted service](https://thegraph.com/hosted-service).
 

--- a/website/route-lockfile.txt
+++ b/website/route-lockfile.txt
@@ -12,7 +12,6 @@
 /ar/cookbook/cosmos/
 /ar/cookbook/grafting/
 /ar/cookbook/near/
-/ar/cookbook/quick-start/
 /ar/cookbook/subgraph-debug-forking/
 /ar/cookbook/subgraph-uncrashable/
 /ar/cookbook/substreams-powered-subgraphs/
@@ -22,7 +21,6 @@
 /ar/deploying/hosted-service/
 /ar/deploying/subgraph-studio-faqs/
 /ar/deploying/subgraph-studio/
-/ar/developing/assemblyscript-api/
 /ar/developing/creating-a-subgraph/
 /ar/developing/developer-faqs/
 /ar/developing/graph-ts/api/
@@ -36,7 +34,6 @@
 /ar/managing/deprecating-a-subgraph/
 /ar/managing/transferring-subgraph-ownership/
 /ar/mips-faqs/
-/ar/network-transition-faq/
 /ar/network/benefits/
 /ar/network/curating/
 /ar/network/delegating/
@@ -54,7 +51,6 @@
 /ar/querying/querying-by-subgraph-id-vs-deployment-id/
 /ar/querying/querying-from-an-application/
 /ar/querying/querying-the-graph/
-/ar/querying/querying-the-hosted-service/
 /ar/querying/querying-with-python/
 /ar/quick-start/
 /ar/release-notes/assemblyscript-migration-guide/
@@ -73,7 +69,6 @@
 /cs/cookbook/cosmos/
 /cs/cookbook/grafting/
 /cs/cookbook/near/
-/cs/cookbook/quick-start/
 /cs/cookbook/subgraph-debug-forking/
 /cs/cookbook/subgraph-uncrashable/
 /cs/cookbook/substreams-powered-subgraphs/
@@ -83,7 +78,6 @@
 /cs/deploying/hosted-service/
 /cs/deploying/subgraph-studio-faqs/
 /cs/deploying/subgraph-studio/
-/cs/developing/assemblyscript-api/
 /cs/developing/creating-a-subgraph/
 /cs/developing/developer-faqs/
 /cs/developing/graph-ts/api/
@@ -97,7 +91,6 @@
 /cs/managing/deprecating-a-subgraph/
 /cs/managing/transferring-subgraph-ownership/
 /cs/mips-faqs/
-/cs/network-transition-faq/
 /cs/network/benefits/
 /cs/network/curating/
 /cs/network/delegating/
@@ -115,7 +108,6 @@
 /cs/querying/querying-by-subgraph-id-vs-deployment-id/
 /cs/querying/querying-from-an-application/
 /cs/querying/querying-the-graph/
-/cs/querying/querying-the-hosted-service/
 /cs/querying/querying-with-python/
 /cs/quick-start/
 /cs/release-notes/assemblyscript-migration-guide/
@@ -134,7 +126,6 @@
 /de/cookbook/cosmos/
 /de/cookbook/grafting/
 /de/cookbook/near/
-/de/cookbook/quick-start/
 /de/cookbook/subgraph-debug-forking/
 /de/cookbook/subgraph-uncrashable/
 /de/cookbook/substreams-powered-subgraphs/
@@ -144,7 +135,6 @@
 /de/deploying/hosted-service/
 /de/deploying/subgraph-studio-faqs/
 /de/deploying/subgraph-studio/
-/de/developing/assemblyscript-api/
 /de/developing/creating-a-subgraph/
 /de/developing/developer-faqs/
 /de/developing/graph-ts/api/
@@ -158,7 +148,6 @@
 /de/managing/deprecating-a-subgraph/
 /de/managing/transferring-subgraph-ownership/
 /de/mips-faqs/
-/de/network-transition-faq/
 /de/network/benefits/
 /de/network/curating/
 /de/network/delegating/
@@ -176,7 +165,6 @@
 /de/querying/querying-by-subgraph-id-vs-deployment-id/
 /de/querying/querying-from-an-application/
 /de/querying/querying-the-graph/
-/de/querying/querying-the-hosted-service/
 /de/querying/querying-with-python/
 /de/quick-start/
 /de/release-notes/assemblyscript-migration-guide/
@@ -268,7 +256,6 @@
 /es/cookbook/cosmos/
 /es/cookbook/grafting/
 /es/cookbook/near/
-/es/cookbook/quick-start/
 /es/cookbook/subgraph-debug-forking/
 /es/cookbook/subgraph-uncrashable/
 /es/cookbook/substreams-powered-subgraphs/
@@ -278,7 +265,6 @@
 /es/deploying/hosted-service/
 /es/deploying/subgraph-studio-faqs/
 /es/deploying/subgraph-studio/
-/es/developing/assemblyscript-api/
 /es/developing/creating-a-subgraph/
 /es/developing/developer-faqs/
 /es/developing/graph-ts/api/
@@ -292,7 +278,6 @@
 /es/managing/deprecating-a-subgraph/
 /es/managing/transferring-subgraph-ownership/
 /es/mips-faqs/
-/es/network-transition-faq/
 /es/network/benefits/
 /es/network/curating/
 /es/network/delegating/
@@ -310,7 +295,6 @@
 /es/querying/querying-by-subgraph-id-vs-deployment-id/
 /es/querying/querying-from-an-application/
 /es/querying/querying-the-graph/
-/es/querying/querying-the-hosted-service/
 /es/querying/querying-with-python/
 /es/quick-start/
 /es/release-notes/assemblyscript-migration-guide/
@@ -329,7 +313,6 @@
 /fr/cookbook/cosmos/
 /fr/cookbook/grafting/
 /fr/cookbook/near/
-/fr/cookbook/quick-start/
 /fr/cookbook/subgraph-debug-forking/
 /fr/cookbook/subgraph-uncrashable/
 /fr/cookbook/substreams-powered-subgraphs/
@@ -339,7 +322,6 @@
 /fr/deploying/hosted-service/
 /fr/deploying/subgraph-studio-faqs/
 /fr/deploying/subgraph-studio/
-/fr/developing/assemblyscript-api/
 /fr/developing/creating-a-subgraph/
 /fr/developing/developer-faqs/
 /fr/developing/graph-ts/api/
@@ -353,7 +335,6 @@
 /fr/managing/deprecating-a-subgraph/
 /fr/managing/transferring-subgraph-ownership/
 /fr/mips-faqs/
-/fr/network-transition-faq/
 /fr/network/benefits/
 /fr/network/curating/
 /fr/network/delegating/
@@ -371,7 +352,6 @@
 /fr/querying/querying-by-subgraph-id-vs-deployment-id/
 /fr/querying/querying-from-an-application/
 /fr/querying/querying-the-graph/
-/fr/querying/querying-the-hosted-service/
 /fr/querying/querying-with-python/
 /fr/quick-start/
 /fr/release-notes/assemblyscript-migration-guide/
@@ -390,7 +370,6 @@
 /ha/cookbook/cosmos/
 /ha/cookbook/grafting/
 /ha/cookbook/near/
-/ha/cookbook/quick-start/
 /ha/cookbook/subgraph-debug-forking/
 /ha/cookbook/subgraph-uncrashable/
 /ha/cookbook/substreams-powered-subgraphs/
@@ -400,7 +379,6 @@
 /ha/deploying/hosted-service/
 /ha/deploying/subgraph-studio-faqs/
 /ha/deploying/subgraph-studio/
-/ha/developing/assemblyscript-api/
 /ha/developing/creating-a-subgraph/
 /ha/developing/developer-faqs/
 /ha/developing/graph-ts/api/
@@ -414,7 +392,6 @@
 /ha/managing/deprecating-a-subgraph/
 /ha/managing/transferring-subgraph-ownership/
 /ha/mips-faqs/
-/ha/network-transition-faq/
 /ha/network/benefits/
 /ha/network/curating/
 /ha/network/delegating/
@@ -432,7 +409,6 @@
 /ha/querying/querying-by-subgraph-id-vs-deployment-id/
 /ha/querying/querying-from-an-application/
 /ha/querying/querying-the-graph/
-/ha/querying/querying-the-hosted-service/
 /ha/querying/querying-with-python/
 /ha/quick-start/
 /ha/release-notes/assemblyscript-migration-guide/
@@ -453,7 +429,6 @@
 /hi/cookbook/cosmos/
 /hi/cookbook/grafting/
 /hi/cookbook/near/
-/hi/cookbook/quick-start/
 /hi/cookbook/subgraph-debug-forking/
 /hi/cookbook/subgraph-uncrashable/
 /hi/cookbook/substreams-powered-subgraphs/
@@ -463,7 +438,6 @@
 /hi/deploying/hosted-service/
 /hi/deploying/subgraph-studio-faqs/
 /hi/deploying/subgraph-studio/
-/hi/developing/assemblyscript-api/
 /hi/developing/creating-a-subgraph/
 /hi/developing/developer-faqs/
 /hi/developing/graph-ts/api/
@@ -477,7 +451,6 @@
 /hi/managing/deprecating-a-subgraph/
 /hi/managing/transferring-subgraph-ownership/
 /hi/mips-faqs/
-/hi/network-transition-faq/
 /hi/network/benefits/
 /hi/network/curating/
 /hi/network/delegating/
@@ -495,7 +468,6 @@
 /hi/querying/querying-by-subgraph-id-vs-deployment-id/
 /hi/querying/querying-from-an-application/
 /hi/querying/querying-the-graph/
-/hi/querying/querying-the-hosted-service/
 /hi/querying/querying-with-python/
 /hi/quick-start/
 /hi/release-notes/assemblyscript-migration-guide/
@@ -514,7 +486,6 @@
 /it/cookbook/cosmos/
 /it/cookbook/grafting/
 /it/cookbook/near/
-/it/cookbook/quick-start/
 /it/cookbook/subgraph-debug-forking/
 /it/cookbook/subgraph-uncrashable/
 /it/cookbook/substreams-powered-subgraphs/
@@ -524,7 +495,6 @@
 /it/deploying/hosted-service/
 /it/deploying/subgraph-studio-faqs/
 /it/deploying/subgraph-studio/
-/it/developing/assemblyscript-api/
 /it/developing/creating-a-subgraph/
 /it/developing/developer-faqs/
 /it/developing/graph-ts/api/
@@ -538,7 +508,6 @@
 /it/managing/deprecating-a-subgraph/
 /it/managing/transferring-subgraph-ownership/
 /it/mips-faqs/
-/it/network-transition-faq/
 /it/network/benefits/
 /it/network/curating/
 /it/network/delegating/
@@ -556,7 +525,6 @@
 /it/querying/querying-by-subgraph-id-vs-deployment-id/
 /it/querying/querying-from-an-application/
 /it/querying/querying-the-graph/
-/it/querying/querying-the-hosted-service/
 /it/querying/querying-with-python/
 /it/quick-start/
 /it/release-notes/assemblyscript-migration-guide/
@@ -577,7 +545,6 @@
 /ja/cookbook/cosmos/
 /ja/cookbook/grafting/
 /ja/cookbook/near/
-/ja/cookbook/quick-start/
 /ja/cookbook/subgraph-debug-forking/
 /ja/cookbook/subgraph-uncrashable/
 /ja/cookbook/substreams-powered-subgraphs/
@@ -587,7 +554,6 @@
 /ja/deploying/hosted-service/
 /ja/deploying/subgraph-studio-faqs/
 /ja/deploying/subgraph-studio/
-/ja/developing/assemblyscript-api/
 /ja/developing/creating-a-subgraph/
 /ja/developing/developer-faqs/
 /ja/developing/graph-ts/api/
@@ -601,7 +567,6 @@
 /ja/managing/deprecating-a-subgraph/
 /ja/managing/transferring-subgraph-ownership/
 /ja/mips-faqs/
-/ja/network-transition-faq/
 /ja/network/benefits/
 /ja/network/curating/
 /ja/network/delegating/
@@ -619,7 +584,6 @@
 /ja/querying/querying-by-subgraph-id-vs-deployment-id/
 /ja/querying/querying-from-an-application/
 /ja/querying/querying-the-graph/
-/ja/querying/querying-the-hosted-service/
 /ja/querying/querying-with-python/
 /ja/quick-start/
 /ja/release-notes/assemblyscript-migration-guide/
@@ -638,7 +602,6 @@
 /ko/cookbook/cosmos/
 /ko/cookbook/grafting/
 /ko/cookbook/near/
-/ko/cookbook/quick-start/
 /ko/cookbook/subgraph-debug-forking/
 /ko/cookbook/subgraph-uncrashable/
 /ko/cookbook/substreams-powered-subgraphs/
@@ -648,7 +611,6 @@
 /ko/deploying/hosted-service/
 /ko/deploying/subgraph-studio-faqs/
 /ko/deploying/subgraph-studio/
-/ko/developing/assemblyscript-api/
 /ko/developing/creating-a-subgraph/
 /ko/developing/developer-faqs/
 /ko/developing/graph-ts/api/
@@ -662,7 +624,6 @@
 /ko/managing/deprecating-a-subgraph/
 /ko/managing/transferring-subgraph-ownership/
 /ko/mips-faqs/
-/ko/network-transition-faq/
 /ko/network/benefits/
 /ko/network/curating/
 /ko/network/delegating/
@@ -680,7 +641,6 @@
 /ko/querying/querying-by-subgraph-id-vs-deployment-id/
 /ko/querying/querying-from-an-application/
 /ko/querying/querying-the-graph/
-/ko/querying/querying-the-hosted-service/
 /ko/querying/querying-with-python/
 /ko/quick-start/
 /ko/release-notes/assemblyscript-migration-guide/
@@ -701,7 +661,6 @@
 /mr/cookbook/cosmos/
 /mr/cookbook/grafting/
 /mr/cookbook/near/
-/mr/cookbook/quick-start/
 /mr/cookbook/subgraph-debug-forking/
 /mr/cookbook/subgraph-uncrashable/
 /mr/cookbook/substreams-powered-subgraphs/
@@ -711,7 +670,6 @@
 /mr/deploying/hosted-service/
 /mr/deploying/subgraph-studio-faqs/
 /mr/deploying/subgraph-studio/
-/mr/developing/assemblyscript-api/
 /mr/developing/creating-a-subgraph/
 /mr/developing/developer-faqs/
 /mr/developing/graph-ts/api/
@@ -725,7 +683,6 @@
 /mr/managing/deprecating-a-subgraph/
 /mr/managing/transferring-subgraph-ownership/
 /mr/mips-faqs/
-/mr/network-transition-faq/
 /mr/network/benefits/
 /mr/network/curating/
 /mr/network/delegating/
@@ -743,7 +700,6 @@
 /mr/querying/querying-by-subgraph-id-vs-deployment-id/
 /mr/querying/querying-from-an-application/
 /mr/querying/querying-the-graph/
-/mr/querying/querying-the-hosted-service/
 /mr/querying/querying-with-python/
 /mr/quick-start/
 /mr/release-notes/assemblyscript-migration-guide/
@@ -762,7 +718,6 @@
 /nl/cookbook/cosmos/
 /nl/cookbook/grafting/
 /nl/cookbook/near/
-/nl/cookbook/quick-start/
 /nl/cookbook/subgraph-debug-forking/
 /nl/cookbook/subgraph-uncrashable/
 /nl/cookbook/substreams-powered-subgraphs/
@@ -772,7 +727,6 @@
 /nl/deploying/hosted-service/
 /nl/deploying/subgraph-studio-faqs/
 /nl/deploying/subgraph-studio/
-/nl/developing/assemblyscript-api/
 /nl/developing/creating-a-subgraph/
 /nl/developing/developer-faqs/
 /nl/developing/graph-ts/api/
@@ -786,7 +740,6 @@
 /nl/managing/deprecating-a-subgraph/
 /nl/managing/transferring-subgraph-ownership/
 /nl/mips-faqs/
-/nl/network-transition-faq/
 /nl/network/benefits/
 /nl/network/curating/
 /nl/network/delegating/
@@ -804,7 +757,6 @@
 /nl/querying/querying-by-subgraph-id-vs-deployment-id/
 /nl/querying/querying-from-an-application/
 /nl/querying/querying-the-graph/
-/nl/querying/querying-the-hosted-service/
 /nl/querying/querying-with-python/
 /nl/quick-start/
 /nl/release-notes/assemblyscript-migration-guide/
@@ -823,7 +775,6 @@
 /pl/cookbook/cosmos/
 /pl/cookbook/grafting/
 /pl/cookbook/near/
-/pl/cookbook/quick-start/
 /pl/cookbook/subgraph-debug-forking/
 /pl/cookbook/subgraph-uncrashable/
 /pl/cookbook/substreams-powered-subgraphs/
@@ -833,7 +784,6 @@
 /pl/deploying/hosted-service/
 /pl/deploying/subgraph-studio-faqs/
 /pl/deploying/subgraph-studio/
-/pl/developing/assemblyscript-api/
 /pl/developing/creating-a-subgraph/
 /pl/developing/developer-faqs/
 /pl/developing/graph-ts/api/
@@ -847,7 +797,6 @@
 /pl/managing/deprecating-a-subgraph/
 /pl/managing/transferring-subgraph-ownership/
 /pl/mips-faqs/
-/pl/network-transition-faq/
 /pl/network/benefits/
 /pl/network/curating/
 /pl/network/delegating/
@@ -865,7 +814,6 @@
 /pl/querying/querying-by-subgraph-id-vs-deployment-id/
 /pl/querying/querying-from-an-application/
 /pl/querying/querying-the-graph/
-/pl/querying/querying-the-hosted-service/
 /pl/querying/querying-with-python/
 /pl/quick-start/
 /pl/release-notes/assemblyscript-migration-guide/
@@ -886,7 +834,6 @@
 /pt/cookbook/cosmos/
 /pt/cookbook/grafting/
 /pt/cookbook/near/
-/pt/cookbook/quick-start/
 /pt/cookbook/subgraph-debug-forking/
 /pt/cookbook/subgraph-uncrashable/
 /pt/cookbook/substreams-powered-subgraphs/
@@ -896,7 +843,6 @@
 /pt/deploying/hosted-service/
 /pt/deploying/subgraph-studio-faqs/
 /pt/deploying/subgraph-studio/
-/pt/developing/assemblyscript-api/
 /pt/developing/creating-a-subgraph/
 /pt/developing/developer-faqs/
 /pt/developing/graph-ts/api/
@@ -910,7 +856,6 @@
 /pt/managing/deprecating-a-subgraph/
 /pt/managing/transferring-subgraph-ownership/
 /pt/mips-faqs/
-/pt/network-transition-faq/
 /pt/network/benefits/
 /pt/network/curating/
 /pt/network/delegating/
@@ -928,7 +873,6 @@
 /pt/querying/querying-by-subgraph-id-vs-deployment-id/
 /pt/querying/querying-from-an-application/
 /pt/querying/querying-the-graph/
-/pt/querying/querying-the-hosted-service/
 /pt/querying/querying-with-python/
 /pt/quick-start/
 /pt/release-notes/assemblyscript-migration-guide/
@@ -947,7 +891,6 @@
 /ro/cookbook/cosmos/
 /ro/cookbook/grafting/
 /ro/cookbook/near/
-/ro/cookbook/quick-start/
 /ro/cookbook/subgraph-debug-forking/
 /ro/cookbook/subgraph-uncrashable/
 /ro/cookbook/substreams-powered-subgraphs/
@@ -957,7 +900,6 @@
 /ro/deploying/hosted-service/
 /ro/deploying/subgraph-studio-faqs/
 /ro/deploying/subgraph-studio/
-/ro/developing/assemblyscript-api/
 /ro/developing/creating-a-subgraph/
 /ro/developing/developer-faqs/
 /ro/developing/graph-ts/api/
@@ -971,7 +913,6 @@
 /ro/managing/deprecating-a-subgraph/
 /ro/managing/transferring-subgraph-ownership/
 /ro/mips-faqs/
-/ro/network-transition-faq/
 /ro/network/benefits/
 /ro/network/curating/
 /ro/network/delegating/
@@ -989,7 +930,6 @@
 /ro/querying/querying-by-subgraph-id-vs-deployment-id/
 /ro/querying/querying-from-an-application/
 /ro/querying/querying-the-graph/
-/ro/querying/querying-the-hosted-service/
 /ro/querying/querying-with-python/
 /ro/quick-start/
 /ro/release-notes/assemblyscript-migration-guide/
@@ -1010,7 +950,6 @@
 /ru/cookbook/cosmos/
 /ru/cookbook/grafting/
 /ru/cookbook/near/
-/ru/cookbook/quick-start/
 /ru/cookbook/subgraph-debug-forking/
 /ru/cookbook/subgraph-uncrashable/
 /ru/cookbook/substreams-powered-subgraphs/
@@ -1020,7 +959,6 @@
 /ru/deploying/hosted-service/
 /ru/deploying/subgraph-studio-faqs/
 /ru/deploying/subgraph-studio/
-/ru/developing/assemblyscript-api/
 /ru/developing/creating-a-subgraph/
 /ru/developing/developer-faqs/
 /ru/developing/graph-ts/api/
@@ -1034,7 +972,6 @@
 /ru/managing/deprecating-a-subgraph/
 /ru/managing/transferring-subgraph-ownership/
 /ru/mips-faqs/
-/ru/network-transition-faq/
 /ru/network/benefits/
 /ru/network/curating/
 /ru/network/delegating/
@@ -1052,7 +989,6 @@
 /ru/querying/querying-by-subgraph-id-vs-deployment-id/
 /ru/querying/querying-from-an-application/
 /ru/querying/querying-the-graph/
-/ru/querying/querying-the-hosted-service/
 /ru/querying/querying-with-python/
 /ru/quick-start/
 /ru/release-notes/assemblyscript-migration-guide/
@@ -1073,7 +1009,6 @@
 /sv/cookbook/cosmos/
 /sv/cookbook/grafting/
 /sv/cookbook/near/
-/sv/cookbook/quick-start/
 /sv/cookbook/subgraph-debug-forking/
 /sv/cookbook/subgraph-uncrashable/
 /sv/cookbook/substreams-powered-subgraphs/
@@ -1083,7 +1018,6 @@
 /sv/deploying/hosted-service/
 /sv/deploying/subgraph-studio-faqs/
 /sv/deploying/subgraph-studio/
-/sv/developing/assemblyscript-api/
 /sv/developing/creating-a-subgraph/
 /sv/developing/developer-faqs/
 /sv/developing/graph-ts/api/
@@ -1097,7 +1031,6 @@
 /sv/managing/deprecating-a-subgraph/
 /sv/managing/transferring-subgraph-ownership/
 /sv/mips-faqs/
-/sv/network-transition-faq/
 /sv/network/benefits/
 /sv/network/curating/
 /sv/network/delegating/
@@ -1115,7 +1048,6 @@
 /sv/querying/querying-by-subgraph-id-vs-deployment-id/
 /sv/querying/querying-from-an-application/
 /sv/querying/querying-the-graph/
-/sv/querying/querying-the-hosted-service/
 /sv/querying/querying-with-python/
 /sv/quick-start/
 /sv/release-notes/assemblyscript-migration-guide/
@@ -1136,7 +1068,6 @@
 /tr/cookbook/cosmos/
 /tr/cookbook/grafting/
 /tr/cookbook/near/
-/tr/cookbook/quick-start/
 /tr/cookbook/subgraph-debug-forking/
 /tr/cookbook/subgraph-uncrashable/
 /tr/cookbook/substreams-powered-subgraphs/
@@ -1146,7 +1077,6 @@
 /tr/deploying/hosted-service/
 /tr/deploying/subgraph-studio-faqs/
 /tr/deploying/subgraph-studio/
-/tr/developing/assemblyscript-api/
 /tr/developing/creating-a-subgraph/
 /tr/developing/developer-faqs/
 /tr/developing/graph-ts/api/
@@ -1160,7 +1090,6 @@
 /tr/managing/deprecating-a-subgraph/
 /tr/managing/transferring-subgraph-ownership/
 /tr/mips-faqs/
-/tr/network-transition-faq/
 /tr/network/benefits/
 /tr/network/curating/
 /tr/network/delegating/
@@ -1178,7 +1107,6 @@
 /tr/querying/querying-by-subgraph-id-vs-deployment-id/
 /tr/querying/querying-from-an-application/
 /tr/querying/querying-the-graph/
-/tr/querying/querying-the-hosted-service/
 /tr/querying/querying-with-python/
 /tr/quick-start/
 /tr/release-notes/assemblyscript-migration-guide/
@@ -1197,7 +1125,6 @@
 /uk/cookbook/cosmos/
 /uk/cookbook/grafting/
 /uk/cookbook/near/
-/uk/cookbook/quick-start/
 /uk/cookbook/subgraph-debug-forking/
 /uk/cookbook/subgraph-uncrashable/
 /uk/cookbook/substreams-powered-subgraphs/
@@ -1207,7 +1134,6 @@
 /uk/deploying/hosted-service/
 /uk/deploying/subgraph-studio-faqs/
 /uk/deploying/subgraph-studio/
-/uk/developing/assemblyscript-api/
 /uk/developing/creating-a-subgraph/
 /uk/developing/developer-faqs/
 /uk/developing/graph-ts/api/
@@ -1221,7 +1147,6 @@
 /uk/managing/deprecating-a-subgraph/
 /uk/managing/transferring-subgraph-ownership/
 /uk/mips-faqs/
-/uk/network-transition-faq/
 /uk/network/benefits/
 /uk/network/curating/
 /uk/network/delegating/
@@ -1239,7 +1164,6 @@
 /uk/querying/querying-by-subgraph-id-vs-deployment-id/
 /uk/querying/querying-from-an-application/
 /uk/querying/querying-the-graph/
-/uk/querying/querying-the-hosted-service/
 /uk/querying/querying-with-python/
 /uk/quick-start/
 /uk/release-notes/assemblyscript-migration-guide/
@@ -1260,7 +1184,6 @@
 /ur/cookbook/cosmos/
 /ur/cookbook/grafting/
 /ur/cookbook/near/
-/ur/cookbook/quick-start/
 /ur/cookbook/subgraph-debug-forking/
 /ur/cookbook/subgraph-uncrashable/
 /ur/cookbook/substreams-powered-subgraphs/
@@ -1270,7 +1193,6 @@
 /ur/deploying/hosted-service/
 /ur/deploying/subgraph-studio-faqs/
 /ur/deploying/subgraph-studio/
-/ur/developing/assemblyscript-api/
 /ur/developing/creating-a-subgraph/
 /ur/developing/developer-faqs/
 /ur/developing/graph-ts/api/
@@ -1284,7 +1206,6 @@
 /ur/managing/deprecating-a-subgraph/
 /ur/managing/transferring-subgraph-ownership/
 /ur/mips-faqs/
-/ur/network-transition-faq/
 /ur/network/benefits/
 /ur/network/curating/
 /ur/network/delegating/
@@ -1302,7 +1223,6 @@
 /ur/querying/querying-by-subgraph-id-vs-deployment-id/
 /ur/querying/querying-from-an-application/
 /ur/querying/querying-the-graph/
-/ur/querying/querying-the-hosted-service/
 /ur/querying/querying-with-python/
 /ur/quick-start/
 /ur/release-notes/assemblyscript-migration-guide/
@@ -1321,7 +1241,6 @@
 /vi/cookbook/cosmos/
 /vi/cookbook/grafting/
 /vi/cookbook/near/
-/vi/cookbook/quick-start/
 /vi/cookbook/subgraph-debug-forking/
 /vi/cookbook/subgraph-uncrashable/
 /vi/cookbook/substreams-powered-subgraphs/
@@ -1331,7 +1250,6 @@
 /vi/deploying/hosted-service/
 /vi/deploying/subgraph-studio-faqs/
 /vi/deploying/subgraph-studio/
-/vi/developing/assemblyscript-api/
 /vi/developing/creating-a-subgraph/
 /vi/developing/developer-faqs/
 /vi/developing/graph-ts/api/
@@ -1345,7 +1263,6 @@
 /vi/managing/deprecating-a-subgraph/
 /vi/managing/transferring-subgraph-ownership/
 /vi/mips-faqs/
-/vi/network-transition-faq/
 /vi/network/benefits/
 /vi/network/curating/
 /vi/network/delegating/
@@ -1363,7 +1280,6 @@
 /vi/querying/querying-by-subgraph-id-vs-deployment-id/
 /vi/querying/querying-from-an-application/
 /vi/querying/querying-the-graph/
-/vi/querying/querying-the-hosted-service/
 /vi/querying/querying-with-python/
 /vi/quick-start/
 /vi/release-notes/assemblyscript-migration-guide/
@@ -1382,7 +1298,6 @@
 /yo/cookbook/cosmos/
 /yo/cookbook/grafting/
 /yo/cookbook/near/
-/yo/cookbook/quick-start/
 /yo/cookbook/subgraph-debug-forking/
 /yo/cookbook/subgraph-uncrashable/
 /yo/cookbook/substreams-powered-subgraphs/
@@ -1392,7 +1307,6 @@
 /yo/deploying/hosted-service/
 /yo/deploying/subgraph-studio-faqs/
 /yo/deploying/subgraph-studio/
-/yo/developing/assemblyscript-api/
 /yo/developing/creating-a-subgraph/
 /yo/developing/developer-faqs/
 /yo/developing/graph-ts/api/
@@ -1406,7 +1320,6 @@
 /yo/managing/deprecating-a-subgraph/
 /yo/managing/transferring-subgraph-ownership/
 /yo/mips-faqs/
-/yo/network-transition-faq/
 /yo/network/benefits/
 /yo/network/curating/
 /yo/network/delegating/
@@ -1424,7 +1337,6 @@
 /yo/querying/querying-by-subgraph-id-vs-deployment-id/
 /yo/querying/querying-from-an-application/
 /yo/querying/querying-the-graph/
-/yo/querying/querying-the-hosted-service/
 /yo/querying/querying-with-python/
 /yo/quick-start/
 /yo/release-notes/assemblyscript-migration-guide/
@@ -1445,7 +1357,6 @@
 /zh/cookbook/cosmos/
 /zh/cookbook/grafting/
 /zh/cookbook/near/
-/zh/cookbook/quick-start/
 /zh/cookbook/subgraph-debug-forking/
 /zh/cookbook/subgraph-uncrashable/
 /zh/cookbook/substreams-powered-subgraphs/
@@ -1455,7 +1366,6 @@
 /zh/deploying/hosted-service/
 /zh/deploying/subgraph-studio-faqs/
 /zh/deploying/subgraph-studio/
-/zh/developing/assemblyscript-api/
 /zh/developing/creating-a-subgraph/
 /zh/developing/developer-faqs/
 /zh/developing/graph-ts/api/
@@ -1469,7 +1379,6 @@
 /zh/managing/deprecating-a-subgraph/
 /zh/managing/transferring-subgraph-ownership/
 /zh/mips-faqs/
-/zh/network-transition-faq/
 /zh/network/benefits/
 /zh/network/curating/
 /zh/network/delegating/
@@ -1487,7 +1396,6 @@
 /zh/querying/querying-by-subgraph-id-vs-deployment-id/
 /zh/querying/querying-from-an-application/
 /zh/querying/querying-the-graph/
-/zh/querying/querying-the-hosted-service/
 /zh/querying/querying-with-python/
 /zh/quick-start/
 /zh/release-notes/assemblyscript-migration-guide/


### PR DESCRIPTION
The previous video included incorrect information about upgraded subgraphs requiring 10k querys in the last 30 days to be published to The Graph Network.

All subgraphs that upgrade will automatically be published to The Graph Network.

The new video reflects this correct information accurately. 