### PR TITLE
refactor: add heading for "Order of Triggering Handlers" section

### DIFF
--- a/website/pages/en/developing/creating-a-subgraph.mdx
+++ b/website/pages/en/developing/creating-a-subgraph.mdx
@@ -174,6 +174,8 @@ The important entries to update for the manifest are:
 
 A single subgraph can index data from multiple smart contracts. Add an entry for each contract from which data needs to be indexed to the `dataSources` array.
 
+### Order of Triggering Handlers
+
 The triggers for a data source within a block are ordered using the following process:
 
 1. Event and call triggers are first ordered by transaction index within the block.


### PR DESCRIPTION
The info about the Order of triggers on the `Creating a Subgraph` Page has less visibility. So giving a heading and making this a section will help devs going through the docs.