### PR TITLE
Document API versions

### DIFF
--- a/website/pages/en/developing/graph-ts/api.mdx
+++ b/website/pages/en/developing/graph-ts/api.mdx
@@ -29,6 +29,8 @@ The `apiVersion` in the subgraph manifest specifies the mapping API version whic
 
 | Version | Release notes |
 | :-: | --- |
+| 0.0.9 | Adds new host function `eth_get_balance` |
+| 0.0.8 | Adds validation for existence of fields in the schema when saving an entity. |
 | 0.0.7 | Added `TransactionReceipt` and `Log` classes to the Ethereum types<br />Added `receipt` field to the Ethereum Event object |
 | 0.0.6 | Added `nonce` field to the Ethereum Transaction object<br />Added `baseFeePerGas` to the Ethereum Block object |
 | 0.0.5 | AssemblyScript upgraded to version 0.19.10 (this includes breaking changes, please see the [`Migration Guide`](/release-notes/assemblyscript-migration-guide))<br />`ethereum.transaction.gasUsed` renamed to `ethereum.transaction.gasLimit` |


### PR DESCRIPTION
[Reference](https://github.com/graphprotocol/graph-node/blob/2f55c034348b9ea84f0d3ca2c14bb1918099b253/graph/src/data/subgraph/api_version.rs#L6-L56)