### PR TITLE
Update substreams-powered-subgraphs.mdx

### DIFF
--- a/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
+++ b/website/pages/en/cookbook/substreams-powered-subgraphs.mdx
@@ -45,7 +45,7 @@ message Contract {
 
 The core logic of the Substreams package is a `map_contract` module in `lib.rs`, which processes every block, filtering for Create calls which did not revert, returning `Contracts`:
 
-```
+```rust
 #[substreams::handlers::map]
 fn map_contract(block: eth::v2::Block) -> Result<Contracts, substreams::errors::Error> {
     let contracts = block
@@ -71,7 +71,7 @@ A Substreams package can be used by a subgraph as long as it has a module which 
 
 > The `substreams_entity_change` crate also has a dedicated `Tables` function for simply generating entity changes ([documentation](https://docs.rs/substreams-entity-change/1.2.2/substreams_entity_change/tables/index.html)). The Entity Changes generated must be compatible with the `schema.graphql` entities defined in the `subgraph.graphql` of the corresponding subgraph.
 
-```
+```rust
 #[substreams::handlers::map]
 pub fn graph_out(contracts: Contracts) -> Result<EntityChanges, substreams::errors::Error> {
     // hash map of name to a table
@@ -90,7 +90,7 @@ pub fn graph_out(contracts: Contracts) -> Result<EntityChanges, substreams::erro
 
 These types and modules are pulled together in `substreams.yaml`:
 
-```
+```yaml
 specVersion: v0.1.0
 package:
   name: 'substreams_test' # the name to be used in the .spkg


### PR DESCRIPTION
Annotation of `rust` block of codes with the `rust` field in the code snippet