### PR TITLE
added indexer upgrade & curation support info

### DIFF
--- a/website/pages/en/publishing/publishing-a-subgraph.mdx
+++ b/website/pages/en/publishing/publishing-a-subgraph.mdx
@@ -2,7 +2,7 @@
 title: Publishing a Subgraph to the Decentralized Network
 ---
 
-Once your subgraph has been [deployed to Subgraph Studio](/deploying/deploying-a-subgraph-to-studio), you have tested it out, and it is ready to put it into production, you can then publish it to the decentralized network.
+Once your subgraph has been [deployed to Subgraph Studio](/deploying/deploying-a-subgraph-to-studio), you have tested it out, and you are ready to put it into production, you can then publish it to the decentralized network.
 
 Publishing a Subgraph to the decentralized network makes it available for [Curators](/network/curating) to begin curating on it, and [Indexers](/network/indexing) to begin indexing it.
 

--- a/website/pages/en/publishing/publishing-a-subgraph.mdx
+++ b/website/pages/en/publishing/publishing-a-subgraph.mdx
@@ -34,7 +34,7 @@ When signaling, Curators can decide to signal on a specific version of the subgr
 
 To assist teams that are transitioning subgraphs from the hosted service to the Graph Network, curation support is now available. If you require assistance with curation to enhance the quality of service, please send a request to the Edge & Node team at support@thegraph.zendesk.com and specify the subgraphs you need assistance with.
 
-Indexers can find subgraphs to index based on curation signals they see in Graph Explorer (screenshot below).
+Indexers can find subgraphs to index based on curation signals they see in Graph Explorer.
 
 ![Explorer subgraphs](/img/explorer-subgraphs.png)
 

--- a/website/pages/en/publishing/publishing-a-subgraph.mdx
+++ b/website/pages/en/publishing/publishing-a-subgraph.mdx
@@ -28,7 +28,7 @@ Developers can add GRT signal to their subgraphs. If a subgraph is eligible for 
 
 > If your subgraph is eligible for rewards, is recommended that you curate your own subgraph with at least 3,000 GRT (as of April 11th, 2024) in order to attract additional indexers to index your subgraph
 
-The [Sunrise Upgrade Indexer](/sunrise/#what-is-the-upgrade-indexer) ensures the indexing of all subgraphs, signaling GRT on a particular subgraph will draw more indexers to it. This incentivization of additional Indexers through curation aims to enhance the quality of service for queries by reducing latency and enhancing network availability.
+The [Sunrise Upgrade Indexer](/sunrise/#what-is-the-upgrade-indexer) ensures the indexing of all subgraphs. However, signaling GRT on a particular subgraph will draw more indexers to it. This incentivization of additional Indexers through curation aims to enhance the quality of service for queries by reducing latency and enhancing network availability.
 
 When signaling, Curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. If they signal using auto-migrate, a curator’s shares will always be updated to the latest version published by the developer. If they decide to signal on a specific version instead, shares will always stay on this specific version.
 

--- a/website/pages/en/publishing/publishing-a-subgraph.mdx
+++ b/website/pages/en/publishing/publishing-a-subgraph.mdx
@@ -32,7 +32,7 @@ The [Sunrise Upgrade Indexer](/sunrise/#what-is-the-upgrade-indexer) ensures the
 
 When signaling, Curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. If they signal using auto-migrate, a curator’s shares will always be updated to the latest version published by the developer. If they decide to signal on a specific version instead, shares will always stay on this specific version.
 
-To assist teams that are transitioning subgraphs from the hosted service to the Graph Network, curation support is now available. If you require assistance with curation to enhance the quality of service, please send a request to the Edge & Node team at support@thegraph.zendesk.com and specify the subgraphs you need assistance with.
+To assist teams that are transitioning subgraphs from the hosted service to The Graph Network, curation support is now available. If you require assistance with curation to enhance the quality of service, please send a request to the Edge & Node team at support@thegraph.zendesk.com and specify the subgraphs you need assistance with.
 
 Indexers can find subgraphs to index based on curation signals they see in Graph Explorer.
 

--- a/website/pages/en/publishing/publishing-a-subgraph.mdx
+++ b/website/pages/en/publishing/publishing-a-subgraph.mdx
@@ -2,7 +2,7 @@
 title: Publishing a Subgraph to the Decentralized Network
 ---
 
-Once your subgraph has been [deployed to Subgraph Studio](/deploying/deploying-a-subgraph-to-studio), you have tested it out, and are ready to put it into production, you can then publish it to the decentralized network.
+Once your subgraph has been [deployed to Subgraph Studio](/deploying/deploying-a-subgraph-to-studio), you have tested it out, and it is ready to put it into production, you can then publish it to the decentralized network.
 
 Publishing a Subgraph to the decentralized network makes it available for [Curators](/network/curating) to begin curating on it, and [Indexers](/network/indexing) to begin indexing it.
 
@@ -27,6 +27,16 @@ Developers can add GRT signal to their subgraphs. If a subgraph is eligible for 
 > Adding signal to a subgraph which is not eligible for rewards will not attract additional Indexers.
 
 > If your subgraph is eligible for rewards, is recommended that you curate your own subgraph with at least 3,000 GRT (as of April 11th, 2024) in order to attract additional indexers to index your subgraph
+
+The [Sunrise Upgrade Indexer](/sunrise/#what-is-the-upgrade-indexer) ensures the indexing of all subgraphs, signaling GRT on a particular subgraph will draw more indexers to it. This incentivization of additional Indexers through curation aims to enhance the quality of service for queries by reducing latency and enhancing network availability.
+
+When signaling, Curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. If they signal using auto-migrate, a curator’s shares will always be updated to the latest version published by the developer. If they decide to signal on a specific version instead, shares will always stay on this specific version.
+
+To assist teams that are transitioning subgraphs from the hosted service to the Graph Network, curation support is now available. If you require assistance with curation to enhance the quality of service, please send a request to the Edge & Node team at support@thegraph.zendesk.com and specify the subgraphs you need assistance with.
+
+Indexers can find subgraphs to index based on curation signals they see in Graph Explorer (screenshot below).
+
+![Explorer subgraphs](/img/explorer-subgraphs.png)
 
 Subgraph Studio enables you to to add signal to your subgraph by adding GRT to your subgraph's curation pool in the same transaction it is published.
 

--- a/website/pages/en/sunrise.mdx
+++ b/website/pages/en/sunrise.mdx
@@ -152,7 +152,12 @@ No, all infrastructure is operated by independent Indexers on The Graph Network,
 
 You can use the [Subgraph Studio](https://thegraph.com/studio/) to create, test, and publish your subgraph. All hosted service users must upgrade their subgraph to The Graph Network before the end of the upgrade window ending on June 12th 2024.
 
-The upgrade Indexer ensures you can query your subgraph even without curation signal.
+The [Sunrise Upgrade Indexer](/sunrise/#what-is-the-upgrade-indexer) ensures the indexing of all subgraphs. However, signaling GRT on a particular subgraph will draw more indexers to it. This incentivization of additional Indexers through curation aims to enhance the quality of service for queries by reducing latency and enhancing network availability.
+
+When signaling, Curators can decide to signal on a specific version of the subgraph or to signal using auto-migrate. If they signal using auto-migrate, a curator’s shares will always be updated to the latest version published by the developer. If they decide to signal on a specific version instead, shares will always stay on that specific version.
+
+To assist teams that are transitioning subgraphs from the hosted service to the Graph Network, curation support is now available. If you require assistance with curation to enhance the quality of service, please send a request to the Edge & Node team at support@thegraph.zendesk.com and specify the subgraphs you need assistance with.
+
 
 Once your subgraph has reached adequate curation signal and other Indexers begin supporting it, the upgrade Indexer will gradually taper off, allowing other Indexers to collect indexing rewards and query fees.
 

--- a/website/pages/en/sunrise.mdx
+++ b/website/pages/en/sunrise.mdx
@@ -158,7 +158,6 @@ When signaling, Curators can decide to signal on a specific version of the subgr
 
 To assist teams that are transitioning subgraphs from the hosted service to the Graph Network, curation support is now available. If you require assistance with curation to enhance the quality of service, please send a request to the Edge & Node team at support@thegraph.zendesk.com and specify the subgraphs you need assistance with.
 
-
 Once your subgraph has reached adequate curation signal and other Indexers begin supporting it, the upgrade Indexer will gradually taper off, allowing other Indexers to collect indexing rewards and query fees.
 
 ### Should I host my own indexing infrastructure?


### PR DESCRIPTION
Not sure if this is still necessary to state "Adding signal to a subgraph which is not eligible for rewards will not attract additional Indexers." 