### PR TITLE
Fix cost model example typo

### DIFF
--- a/website/pages/en/network/indexing.mdx
+++ b/website/pages/en/network/indexing.mdx
@@ -735,7 +735,7 @@ Example query costing using the above model:
 | ---------------------------------------------------------------------------- | ------- |
 | &#123; pairs(skip: 5000) &#123; id &#125; &#125;                             | 0.5 GRT |
 | &#123; tokens &#123; symbol &#125; &#125;                                    | 0.1 GRT |
-| &#123; pairs(skip: 5000) &#123; id &#123; tokens &#125; symbol &#125; &#125; | 0.6 GRT |
+| &#123; pairs(skip: 5000) &#123; id &#125; tokens &#123; symbol &#125; &#125; | 0.6 GRT |
 
 #### Applying the cost model
 


### PR DESCRIPTION
The query was invalid, this fixes it
Before: `{ pairs(skip: 5000) { id { tokens } symbol } }`
After: `{ pairs(skip: 5000) { id } tokens { symbol } }`