### PR TITLE
Update api.mdx

### DIFF
--- a/website/pages/en/developing/graph-ts/api.mdx
+++ b/website/pages/en/developing/graph-ts/api.mdx
@@ -534,7 +534,7 @@ For more information:
 
 - [ABI Spec](https://docs.soliditylang.org/en/v0.7.4/abi-spec.html#types)
 - Encoding/decoding [Rust library/CLI](https://github.com/rust-ethereum/ethabi)
-- More [complex example](https://github.com/graphprotocol/graph-node/blob/6a7806cc465949ebb9e5b8269eeb763857797efc/tests/integration-tests/host-exports/src/mapping.ts#L72).
+- More [complex example](https://github.com/graphprotocol/graph-node/blob/08da7cb46ddc8c09f448c5ea4b210c9021ea05ad/tests/integration-tests/host-exports/src/mapping.ts#L86).
 
 #### Balance of an Address
 


### PR DESCRIPTION
Updates the link to the latest commit to the updated test for complex encoding and decoding ethereum abi.

The current linked commit is not a correct example and no longer exists in the repository