### PR TITLE
fix: remove dead sidebar links

### DIFF
--- a/website/pages/en/deploying/_meta.js
+++ b/website/pages/en/deploying/_meta.js
@@ -2,6 +2,4 @@ export default {
   'subgraph-studio': '',
   'deploying-a-subgraph-to-studio': '',
   'subgraph-studio-faqs': '',
-  'hosted-service': '',
-  'deploying-a-subgraph-to-hosted': '',
 }


### PR DESCRIPTION
Looks like this might have been missed here
https://github.com/graphprotocol/docs/pull/740/files cc: @MichaelMacaulay

These links are dead
![image](https://github.com/user-attachments/assets/f91019d5-ff9a-4f8c-a4ff-3ca344a5c5ff)
