### PR TITLE
Redirect TAP Version to indexer docs

### DIFF
--- a/website/pages/ar/tap.mdx
+++ b/website/pages/ar/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/cs/tap.mdx
+++ b/website/pages/cs/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/de/tap.mdx
+++ b/website/pages/de/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/en/tap.mdx
+++ b/website/pages/en/tap.mdx
@@ -72,11 +72,7 @@ In addition to the typical requirements to run an indexer, you’ll need a `tap-
 
 ### Software versions
 
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 

--- a/website/pages/es/tap.mdx
+++ b/website/pages/es/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/fr/tap.mdx
+++ b/website/pages/fr/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/ha/tap.mdx
+++ b/website/pages/ha/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/hi/tap.mdx
+++ b/website/pages/hi/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/it/tap.mdx
+++ b/website/pages/it/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/ja/tap.mdx
+++ b/website/pages/ja/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/ko/tap.mdx
+++ b/website/pages/ko/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/mr/tap.mdx
+++ b/website/pages/mr/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/nl/tap.mdx
+++ b/website/pages/nl/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/pl/tap.mdx
+++ b/website/pages/pl/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/pt/tap.mdx
+++ b/website/pages/pt/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/ro/tap.mdx
+++ b/website/pages/ro/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/ru/tap.mdx
+++ b/website/pages/ru/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/sv/tap.mdx
+++ b/website/pages/sv/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/tr/tap.mdx
+++ b/website/pages/tr/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/uk/tap.mdx
+++ b/website/pages/uk/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/ur/tap.mdx
+++ b/website/pages/ur/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/vi/tap.mdx
+++ b/website/pages/vi/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/yo/tap.mdx
+++ b/website/pages/yo/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 

--- a/website/pages/zh/tap.mdx
+++ b/website/pages/zh/tap.mdx
@@ -45,53 +45,58 @@ As long as you run `tap-agent` and `indexer-agent`, everything will be executed 
 
 ### Contracts
 
-| Contract            | Arbitrum Sepolia                           | Arbitrum Mainnet                           |
-| ------------------- | ------------------------------------------ | ------------------------------------------ |
-| Contract            | Arbitrum Sepolia (421614)                  | Arbitrum Mainnet (42161)                   |
-| TAP Verifier        | 0xfC24cE7a4428A6B89B52645243662A02BA734ECF | 0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a |
-| AllocationIDTracker | 0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11 | 0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c |
-| Escrow              | 0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02 | 0x8f477709eF277d4A880801D01A140a9CF88bA0d3 |
+| Contract            | Arbitrum Sepolia (421614)                    | Arbitrum Mainnet (42161)                     |
+| ------------------- | -------------------------------------------- | -------------------------------------------- |
+| TAP Verifier        | `0xfC24cE7a4428A6B89B52645243662A02BA734ECF` | `0x33f9E93266ce0E108fc85DdE2f71dab555A0F05a` |
+| AllocationIDTracker | `0xAaC28a10d707bbc6e02029f1bfDAEB5084b2aD11` | `0x5B2F33d7Ca6Ec88f5586f2528f58c20843D9FE7c` |
+| Escrow              | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` |
 
 ### Gateway
 
-| Component | Edge and Node (Testnet) | Edge and Node Mainnet (42161) |
-| --- | --- | --- |
-| Sender | 0xC3dDf37906724732FfD748057FEBe23379b0710D | 0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 |
-| Signers | 00xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE | 0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211 |
-| Aggregator | [for testnet](https://tap-aggregator.testnet.thegraph.com) | [for Mainnet](https://tap-aggregator.network.thegraph.com) |
+| Component  | Edge and Node Mainnet (Arbitrum Sepolia)      | Edge and Node Testnet (Aribtrum Mainnet)      |
+| ---------- | --------------------------------------------- | --------------------------------------------- |
+| Sender     | `0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467`  | `0xC3dDf37906724732FfD748057FEBe23379b0710D`  |
+| Signers    | `0xfF4B7A5EfD00Ff2EC3518D4F250A27e4c29A2211`  | `0xFb142dE83E261e43a81e9ACEADd1c66A0DB121FE`  |
+| Aggregator | `https://tap-aggregator.network.thegraph.com` | `https://tap-aggregator.testnet.thegraph.com` |
 
 ### Requirements
 
 In addition to the typical requirements to run an indexer, you’ll need a `tap-escrow-subgraph` endpoint to query TAP updates. You can use The Graph Network to query or host yourself on your `graph-node`.
 
-> Note: `indexer-cli` does not currently have a command to index this subgraph like it does for `graph-network`. As a result, you have to index it manually.
+- [Graph TAP Aribtrum Sepolia subgraph (for The Graph testnet)](https://thegraph.com/explorer/subgraphs/7ubx365MiqBH5iUz6XWXWT8PTof5BVAyEzdb8m17RvbD)
+- [Graph TAP Arbitrum One subgraph (for The Graph mainnet)](https://thegraph.com/explorer/subgraphs/4sukbNVTzGELnhdnpyPqsf1QqtzNHEYKKmJkgaT8z6M1)
+
+> Note: `indexer-agent` does not currently handle the indexing of this subgraph like it does for the network subgraph deployement. As a result, you have to index it manually.
 
 ## Migration Guide
 
-### Prerequisites
+### Software versions
 
-Make sure you have the following version: `<insert the version here>`
+The required software version can be found [here](https://github.com/graphprotocol/indexer/blob/main/docs/networks/arbitrum-one.md#latest-releases).
 
 ### Steps
 
 1. **Indexer Agent**
 
    - Follow the [same process](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent#graph-protocol-indexer-components).
-   - Use the new argument `–tap-subgraph-endpoint`.
+   - Give the new argument `--tap-subgraph-endpoint` to activate the new TAP codepaths and enable redeeming of TAP RAVs.
 
 2. **Indexer Service**
 
-   - Fully replace your current configuration with the new application.
-   - You can reuse some of the values in your environment variables and command arguments inside the configuration.
-     > It’s critical to install the new `tap-agent` component to receive your payments.
+   - Fully replace your current configuration with the [new Indexer Service rs](https://github.com/graphprotocol/indexer-rs). It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+   - Like the older version, you can scale Indexer Service horizontally easily. It is still stateless.
 
-3. **Configure**
+3. **TAP Agent**
 
-   Configuration is shared between components, enabling you to use a single configuration for both `indexer-service` and `tap-agent`. Each component will use the required fields.
+   - Run _one_ single instance of [TAP Agent](https://github.com/graphprotocol/indexer-rs) at all times. It's recommend that you use the [container image](https://github.com/orgs/graphprotocol/packages?repo_name=indexer-rs).
+
+4. **Configure Indexer Service and TAP Agent**
+
+   Configuration is a TOML file shared between `indexer-service` and `tap-agent`, supplied with the argument `--config /path/to/config.toml`.
 
    Check out the full [configuration](https://github.com/graphprotocol/indexer-rs/blob/main/config/maximal-config-example.toml) and the [default values](https://github.com/graphprotocol/indexer-rs/blob/main/config/default_values.toml)
 
-For minimal configuration, use the following:
+For minimal configuration, use the following template:
 
 ```bash
 # You will have to change *all* the values below to match your setup.
@@ -159,26 +164,14 @@ max_amount_willing_to_lose_grt = 20
 
 [tap.sender_aggregator_endpoints]
 # Key-Value of all senders and their aggregator endpoints
-0xdeadbeefcafebabedeadbeefcafebabedeadbeef = "https://example.com/aggregate-receipts"
-0x0123456789abcdef0123456789abcdef01234567 = "https://other.example.com/aggregate-receipts"
+# This one below is for the E&N testnet gateway for example.
+0xDDE4cfFd3D9052A9cb618fC05a1Cd02be1f2F467 = "https://tap-aggregator.network.thegraph.com"
 ```
 
 Notes:
 
 - Values for `tap.sender_aggregator_endpoints` can be found in the [gateway section](/tap/#gateway).
 - Values for `blockchain.receipts_verifier_address` must be used accordingly to the [Blockchain addresses section](/tap/#contracts) using the appropriate chain id.
-
-### Running
-
-| Component | Version | Image Link |
-| --- | --- | --- |
-| indexer-service | v1.0.0-rc.6 | [indexer-service](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-service-rs/264320627?tag=1.0.0-rc.6) |
-| indexer-agent | PR #995 | [indexer-agent](https://github.com/graphprotocol/indexer/pkgs/container/indexer-agent/266166026?tag=sha-d98cf80) |
-| tap-agent | v1.0.0-rc.6 | [tap-agent](https://github.com/graphprotocol/indexer-rs/pkgs/container/indexer-tap-agent/264320547?tag=1.0.0-rc.6) |
-
-**Command argument**
-
-With a configuration file `config.toml` setup, you can either run the following docker-image or use the config args: `--config/path/to/config.toml`
 
 **Log Level**
 


### PR DESCRIPTION
Updated the `en/tap.mdx` file and copied it to all other languages.