### PR TITLE
Fix broken launchpad chart link

### DIFF
--- a/website/pages/en/tap.mdx
+++ b/website/pages/en/tap.mdx
@@ -194,4 +194,4 @@ You can download [Grafana Dashboard](https://github.com/graphprotocol/indexer-rs
 
 ### Launchpad
 
-Currently, there is a WIP version of `indexer-rs` and `tap-agent` that can be found [here](https://github.com/graphops/launchpad-charts/tree/feat/indexer-rs/charts/graph-network-indexer)
+Currently, there is a WIP version of `indexer-rs` and `tap-agent` that can be found [here](https://github.com/graphops/launchpad-charts/tree/main/charts/graph-network-indexer)


### PR DESCRIPTION
The link for the Launchpad section was pointing to a PR that was merged some time ago. Changing the path to the correct location found on the main branch.