### PR TITLE
fix strings to bytes conversions funcs

### DIFF
--- a/website/pages/en/subgraphs/developing/creating/graph-ts/api.mdx
+++ b/website/pages/en/subgraphs/developing/creating/graph-ts/api.mdx
@@ -800,8 +800,8 @@ When the type of a value is certain, it can be converted to a [built-in type](#b
 | Bytes                | Address              | Address.fromBytes(s)         |
 | String               | BigInt               | BigInt.fromString(s)         |
 | String               | BigDecimal           | BigDecimal.fromString(s)     |
-| String (hexadecimal) | Bytes                | ByteArray.fromHexString(s)   |
-| String (UTF-8)       | Bytes                | ByteArray.fromUTF8(s)        |
+| String (hexadecimal) | Bytes                | Bytes.fromHexString(s)   |
+| String (UTF-8)       | Bytes                | Bytes.fromUTF8(s)        |
 
 ### Data Source Metadata
 


### PR DESCRIPTION
`ERROR TS2322: Type '~lib/@graphprotocol/graph-ts/common/collections/ByteArray' is not assignable to type '~lib/@graphprotocol/graph-ts/common/collections/Bytes'.`