### PR TITLE
fix(docs): explain better where the deploy key is located

### DIFF
--- a/website/src/pages/en/subgraphs/quick-start.mdx
+++ b/website/src/pages/en/subgraphs/quick-start.mdx
@@ -92,7 +92,7 @@ Once your Subgraph is written, run the following commands:
     graph codegen && graph build
     ```
 
-Authenticate and deploy your Subgraph. The deploy key can be found on the Subgraph's page in Subgraph Studio.
+Authenticate and deploy your Subgraph. The deploy key can be found on the Subgraph's page in Subgraph Studio (It is not in the API Key section on the top navbar).
 
 ![Deploy key](/img/subgraph-studio-deploy-key.jpg)
 


### PR DESCRIPTION
I just spend 3 hours trying to debug a silly mistake: I thought that the deploy key was the one generated in the API Keys section. I think a more explicit description is needed.