### PR TITLE
Update quick-start.mdx

### DIFF
--- a/website/src/pages/en/token-api/quick-start.mdx
+++ b/website/src/pages/en/token-api/quick-start.mdx
@@ -41,7 +41,7 @@ const options = {
   },
 }
 
-fetch(`https://token-api.service.pinax.network/balances/evm/${address}`, options)
+fetch(`https://token-api.thegraph.com/balances/evm/${address}`, options)
   .then((response) => response.json())
   .then((response) => console.log(response))
   .catch((err) => console.error(err))
@@ -55,7 +55,7 @@ To make an API request using **cURL**, open your command line and run the follow
 
 ```curl
 curl --request GET \
-  --url https://token-api.service.pinax.network/balances/evm/0x2a0c0dbecc7e4d658f48e01e3fa353f44050c208 \
+  --url https://token-api.thegraph.com/balances/evm/0x2a0c0dbecc7e4d658f48e01e3fa353f44050c208 \
   --header 'Accept: application/json' \
   --header 'Authorization: Bearer <token>'
 ```
@@ -69,7 +69,7 @@ Make sure to replace `<token>` with the JWT Token generated from your API key.
 If the API call fails, try printing out the full response object for additional error details. For example:
 
 ```js label="index.js"
-fetch(`https://token-api.service.pinax.network/balances/evm/${address}`, options)
+fetch(`https://token-api.thegraph.com/balances/evm/${address}`, options)
   .then((response) => {
     console.log('Status Code:', response.status)
     return response.json()


### PR DESCRIPTION
Changed example endpoints to https://token-api.thegraph.com/ instead of https://token-api.service.pinax.network