### PR TITLE
Supported networks table

### DIFF
--- a/website/src/pages/en/index.json
+++ b/website/src/pages/en/index.json
@@ -88,7 +88,12 @@
       },
       "tokenApi": {
         "supported": "All endpoints supported"
-      }
+      },
+      "icons": {
+        "checkmark": "Checkmark",
+        "checkmarks": "Checkmarks"
+      },
+      "legendTitle": "Table Legend"
     }
   },
   "networkGuides": {

--- a/website/src/pages/en/index.json
+++ b/website/src/pages/en/index.json
@@ -72,6 +72,23 @@
       "substreams": "Substreams",
       "firehose": "Firehose",
       "tokenApi": "Token API"
+    },
+    "tableLegend": {
+      "subgraphs": {
+        "basic": "Subgraph Studio (No issuance)",
+        "full": "The Graph Network (Issuance)"
+      },
+      "substreams": {
+        "basic": "Base",
+        "full": "Extended (EVM Only)"
+      },
+      "firehose": {
+        "basic": "Base",
+        "full": "Extended (EVM Only)"
+      },
+      "tokenApi": {
+        "supported": "All endpoints supported"
+      }
     }
   },
   "networkGuides": {

--- a/website/src/supportedNetworks/NetworksTable.tsx
+++ b/website/src/supportedNetworks/NetworksTable.tsx
@@ -59,45 +59,45 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
       </Callout>
 
       <div className="mb-6 overflow-clip rounded-8 border border-space-1500 bg-space-1800">
-        <div className="grid grid-cols-2 gap-px text-space-500">
+        <div className="grid grid-cols-1 gap-px text-space-500 xs:grid-cols-2">
           <div className="border-b border-r border-space-1500 p-4">
             <Text.C10 className="mb-2 uppercase text-white">Subgraphs</Text.C10>
             <div className="flex items-center gap-2">
               <Check size={4} alt="Checkmark" />
-              <span className="text-14">Subgraph Studio (No issuance)</span>
+              <span className="text-14">{t('index.supportedNetworks.tableLegend.subgraphs.basic')}</span>
             </div>
             <div className="flex items-center gap-2">
               <Checks size={4} alt="Checkmarks" />
-              <span className="text-14">The Graph Network (Issuance)</span>
+              <span className="text-14">{t('index.supportedNetworks.tableLegend.subgraphs.full')}</span>
             </div>
           </div>
           <div className="border-b border-r border-space-1500 p-4 lg:border-r-0">
             <Text.C10 className="mb-2 uppercase text-white">Substreams</Text.C10>
             <div className="flex items-center gap-2">
               <Check size={4} alt="Checkmark" />
-              <span className="text-14">Base</span>
+              <span className="text-14">{t('index.supportedNetworks.tableLegend.substreams.basic')}</span>
             </div>
             <div className="flex items-center gap-2">
               <Checks size={4} alt="Checkmarks" />
-              <span className="text-14">Extended (EVM Only)</span>
+              <span className="text-14">{t('index.supportedNetworks.tableLegend.substreams.full')}</span>
             </div>
           </div>
           <div className="border-b border-r border-space-1500 p-4">
             <Text.C10 className="mb-2 uppercase text-white">Firehose</Text.C10>
             <div className="flex items-center gap-2">
               <Check size={4} alt="Checkmark" />
-              <span className="text-14">Base</span>
+              <span className="text-14">{t('index.supportedNetworks.tableLegend.firehose.basic')}</span>
             </div>
             <div className="flex items-center gap-2">
               <Checks size={4} alt="Checkmarks" />
-              <span className="text-14">Extended (EVM Only)</span>
+              <span className="text-14">{t('index.supportedNetworks.tableLegend.firehose.full')}</span>
             </div>
           </div>
           <div className="p-4">
             <Text.C10 className="mb-2 uppercase text-white">Token API</Text.C10>
             <div className="flex items-center gap-2">
               <Check size={4} alt="Checkmark" />
-              <span className="text-14">All endpoints supported</span>
+              <span className="text-14">{t('index.supportedNetworks.tableLegend.tokenApi.supported')}</span>
             </div>
           </div>
         </div>

--- a/website/src/supportedNetworks/NetworksTable.tsx
+++ b/website/src/supportedNetworks/NetworksTable.tsx
@@ -24,6 +24,13 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
   const [immediateSearchQuery, setSearchQuery] = useState('')
   const [immediateShowTestnets, setShowTestnets] = useState(false)
 
+  const checkmark = (
+    <Check size={4} alt={t('index.supportedNetworks.tableLegend.icons.checkmark')} className="h-[0.75lh]" />
+  )
+  const checkmarks = (
+    <Checks size={4} alt={t('index.supportedNetworks.tableLegend.icons.checkmarks')} className="h-[0.75lh]" />
+  )
+
   const searchQuery = useDebounce(immediateSearchQuery, 200)
   const showTestnets = useDebounce(immediateShowTestnets, 200)
 
@@ -58,50 +65,56 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
         </p>
       </Callout>
 
-      <div className="mb-6 overflow-clip rounded-8 border border-space-1500 bg-space-1800">
+      <aside
+        className="mb-6 overflow-clip rounded-8 border border-space-1500 bg-space-1800"
+        aria-labelledby="networks-table-legend"
+      >
+        <h3 id="networks-table-legend" className="sr-only">
+          {t('index.supportedNetworks.tableLegend.legendTitle')}
+        </h3>
         <div className="grid grid-cols-1 gap-px text-space-500 xs:grid-cols-2">
           <div className="border-b border-r border-space-1500 p-4">
-            <Text.C10 className="mb-2 uppercase text-white">Subgraphs</Text.C10>
-            <div className="flex items-center gap-2">
-              <Check size={4} alt="Checkmark" />
+            <span className="text-c10 mb-2 block text-white">Subgraphs</span>
+            <div className="flex gap-2">
+              {checkmark}
               <span className="text-14">{t('index.supportedNetworks.tableLegend.subgraphs.basic')}</span>
             </div>
-            <div className="flex items-center gap-2">
-              <Checks size={4} alt="Checkmarks" />
+            <div className="flex gap-2">
+              {checkmarks}
               <span className="text-14">{t('index.supportedNetworks.tableLegend.subgraphs.full')}</span>
             </div>
           </div>
           <div className="border-b border-r border-space-1500 p-4 lg:border-r-0">
-            <Text.C10 className="mb-2 uppercase text-white">Substreams</Text.C10>
-            <div className="flex items-center gap-2">
-              <Check size={4} alt="Checkmark" />
+            <span className="text-c10 mb-2 block text-white">Substreams</span>
+            <div className="flex gap-2">
+              {checkmark}
               <span className="text-14">{t('index.supportedNetworks.tableLegend.substreams.basic')}</span>
             </div>
-            <div className="flex items-center gap-2">
-              <Checks size={4} alt="Checkmarks" />
+            <div className="flex gap-2">
+              {checkmarks}
               <span className="text-14">{t('index.supportedNetworks.tableLegend.substreams.full')}</span>
             </div>
           </div>
           <div className="border-b border-r border-space-1500 p-4">
-            <Text.C10 className="mb-2 uppercase text-white">Firehose</Text.C10>
-            <div className="flex items-center gap-2">
-              <Check size={4} alt="Checkmark" />
+            <span className="text-c10 mb-2 block text-white">Firehose</span>
+            <div className="flex gap-2">
+              {checkmark}
               <span className="text-14">{t('index.supportedNetworks.tableLegend.firehose.basic')}</span>
             </div>
-            <div className="flex items-center gap-2">
-              <Checks size={4} alt="Checkmarks" />
+            <div className="flex gap-2">
+              {checkmarks}
               <span className="text-14">{t('index.supportedNetworks.tableLegend.firehose.full')}</span>
             </div>
           </div>
           <div className="p-4">
-            <Text.C10 className="mb-2 uppercase text-white">Token API</Text.C10>
-            <div className="flex items-center gap-2">
-              <Check size={4} alt="Checkmark" />
+            <span className="text-c10 mb-2 block text-white">Token API</span>
+            <div className="flex gap-2">
+              {checkmark}
               <span className="text-14">{t('index.supportedNetworks.tableLegend.tokenApi.supported')}</span>
             </div>
           </div>
         </div>
-      </div>
+      </aside>
 
       <div className="mb-4 flex items-center gap-4">
         <div className="flex-grow">
@@ -167,7 +180,7 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
                 className="group/table-row isolate -outline-offset-1 transition hocus-visible-within:bg-space-1600 has-[a:focus-visible]:outline-focus"
               >
                 <td>
-                  <div className="flex items-center justify-between gap-2">
+                  <div className="static flex items-center justify-between gap-2">
                     <ButtonOrLink href={`/supported-networks/${network.id}`} className="static outline-none">
                       <div className="flex items-center gap-3">
                         <NetworkIcon network={network} variant={getIconVariant(network.id)} size={5} />
@@ -184,27 +197,27 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
                   </div>
                 </td>
                 <td align="center">
-                  {network.subgraphsSupportLevel === 'full' ? (
-                    <Checks size={4} alt="Checkmarks" />
-                  ) : network.subgraphsSupportLevel === 'basic' ? (
-                    <Check size={4} alt="Checkmark" />
-                  ) : null}
+                  {network.subgraphsSupportLevel === 'full'
+                    ? checkmarks
+                    : network.subgraphsSupportLevel === 'basic'
+                      ? checkmark
+                      : null}
                 </td>
                 <td align="center">
-                  {network.substreamsSupportLevel === 'full' ? (
-                    <Checks size={4} alt="Checkmarks" />
-                  ) : network.substreamsSupportLevel === 'basic' ? (
-                    <Check size={4} alt="Checkmark" />
-                  ) : null}
+                  {network.substreamsSupportLevel === 'full'
+                    ? checkmarks
+                    : network.substreamsSupportLevel === 'basic'
+                      ? checkmark
+                      : null}
                 </td>
                 <td align="center">
-                  {network.firehoseSupportLevel === 'full' ? (
-                    <Checks size={4} alt="Checkmarks" />
-                  ) : network.firehoseSupportLevel === 'basic' ? (
-                    <Check size={4} alt="Checkmark" />
-                  ) : null}
+                  {network.firehoseSupportLevel === 'full'
+                    ? checkmarks
+                    : network.firehoseSupportLevel === 'basic'
+                      ? checkmark
+                      : null}
                 </td>
-                <td align="center">{network.tokenApi ? <Check size={4} alt="Checkmark" /> : null}</td>
+                <td align="center">{network.tokenApi ? checkmark : null}</td>
               </tr>
             ))}
           </tbody>

--- a/website/src/supportedNetworks/NetworksTable.tsx
+++ b/website/src/supportedNetworks/NetworksTable.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   useDebounce,
 } from '@edgeandnode/gds'
-import { Check, EyeClosed } from '@edgeandnode/gds/icons'
+import { Check, Checks, EyeClosed } from '@edgeandnode/gds/icons'
 import { NetworkIcon } from '@edgeandnode/go'
 
 import { Callout, Table } from '@/components'
@@ -58,6 +58,51 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
         </p>
       </Callout>
 
+      <div className="mb-6 overflow-clip rounded-8 border border-space-1500 bg-space-1800">
+        <div className="grid grid-cols-2 gap-px text-space-500">
+          <div className="border-b border-r border-space-1500 p-4">
+            <Text.C10 className="mb-2 uppercase text-white">Subgraphs</Text.C10>
+            <div className="flex items-center gap-2">
+              <Check size={4} alt="Checkmark" />
+              <span className="text-14">Subgraph Studio (No issuance)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checks size={4} alt="Checkmarks" />
+              <span className="text-14">The Graph Network (Issuance)</span>
+            </div>
+          </div>
+          <div className="border-b border-r border-space-1500 p-4 lg:border-r-0">
+            <Text.C10 className="mb-2 uppercase text-white">Substreams</Text.C10>
+            <div className="flex items-center gap-2">
+              <Check size={4} alt="Checkmark" />
+              <span className="text-14">Base</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checks size={4} alt="Checkmarks" />
+              <span className="text-14">Extended (EVM Only)</span>
+            </div>
+          </div>
+          <div className="border-b border-r border-space-1500 p-4">
+            <Text.C10 className="mb-2 uppercase text-white">Firehose</Text.C10>
+            <div className="flex items-center gap-2">
+              <Check size={4} alt="Checkmark" />
+              <span className="text-14">Base</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checks size={4} alt="Checkmarks" />
+              <span className="text-14">Extended (EVM Only)</span>
+            </div>
+          </div>
+          <div className="p-4">
+            <Text.C10 className="mb-2 uppercase text-white">Token API</Text.C10>
+            <div className="flex items-center gap-2">
+              <Check size={4} alt="Checkmark" />
+              <span className="text-14">All endpoints supported</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div className="mb-4 flex items-center gap-4">
         <div className="flex-grow">
           <ExperimentalSearch
@@ -103,9 +148,6 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
               <th className="min-w-47">
                 <Text.C10>{t('index.supportedNetworks.tableHeaders.name')}</Text.C10>
               </th>
-              <th className="min-w-47">
-                <Text.C10>{t('index.supportedNetworks.tableHeaders.id')}</Text.C10>
-              </th>
               <th align="center">
                 <Text.C10>{t('index.supportedNetworks.tableHeaders.subgraphs')}</Text.C10>
               </th>
@@ -125,25 +167,43 @@ export function NetworksTable({ networks }: { networks: SupportedNetwork[] }) {
                 className="group/table-row isolate -outline-offset-1 transition hocus-visible-within:bg-space-1600 has-[a:focus-visible]:outline-focus"
               >
                 <td>
-                  <ButtonOrLink href={`/supported-networks/${network.id}`} className="static outline-none">
-                    <span className="flex items-center gap-2">
-                      <NetworkIcon network={network} variant={getIconVariant(network.id)} size={5} />
-                      <span className="text-body-xsmall">{network.shortName}</span>
-                    </span>
-                    <span className="absolute inset-y-0 start-0 z-10 w-[1999px]" />
-                  </ButtonOrLink>
-                </td>
-                <td>
                   <div className="flex items-center justify-between gap-2">
-                    <span className="text-body-xsmall">{network.id}</span>
+                    <ButtonOrLink href={`/supported-networks/${network.id}`} className="static outline-none">
+                      <div className="flex items-center gap-3">
+                        <NetworkIcon network={network} variant={getIconVariant(network.id)} size={5} />
+                        <div className="flex flex-col">
+                          <span className="text-body-xsmall leading-5 text-white">{network.shortName}</span>
+                          <span className="text-body-xsmall leading-5 text-space-500">{network.id}</span>
+                        </div>
+                      </div>
+                      <span className="absolute inset-y-0 start-0 z-10 w-[1999px]" />
+                    </ButtonOrLink>
                     <div className="z-20 shrink-0 opacity-0 transition group-focus-within/table-row:opacity-100 group-hover/table-row:opacity-100">
                       <ExperimentalCopyButton size="small" variant="tertiary" value={network.id} />
                     </div>
                   </div>
                 </td>
-                <td align="center">{network.subgraphs ? <Check size={4} alt="Checkmark" /> : null}</td>
-                <td align="center">{network.substreams ? <Check size={4} alt="Checkmark" /> : null}</td>
-                <td align="center">{network.firehose ? <Check size={4} alt="Checkmark" /> : null}</td>
+                <td align="center">
+                  {network.subgraphsSupportLevel === 'full' ? (
+                    <Checks size={4} alt="Checkmarks" />
+                  ) : network.subgraphsSupportLevel === 'basic' ? (
+                    <Check size={4} alt="Checkmark" />
+                  ) : null}
+                </td>
+                <td align="center">
+                  {network.substreamsSupportLevel === 'full' ? (
+                    <Checks size={4} alt="Checkmarks" />
+                  ) : network.substreamsSupportLevel === 'basic' ? (
+                    <Check size={4} alt="Checkmark" />
+                  ) : null}
+                </td>
+                <td align="center">
+                  {network.firehoseSupportLevel === 'full' ? (
+                    <Checks size={4} alt="Checkmarks" />
+                  ) : network.firehoseSupportLevel === 'basic' ? (
+                    <Check size={4} alt="Checkmark" />
+                  ) : null}
+                </td>
                 <td align="center">{network.tokenApi ? <Check size={4} alt="Checkmark" /> : null}</td>
               </tr>
             ))}

--- a/website/src/supportedNetworks/utils.ts
+++ b/website/src/supportedNetworks/utils.ts
@@ -1,4 +1,4 @@
-import { NetworksRegistry } from '@pinax/graph-networks-registry'
+import { NetworksRegistry, type Network } from '@pinax/graph-networks-registry'
 
 // Networks that should use the "mono" icon variant (TODO: add this feature to web3icons?)
 export const MONO_ICON_NETWORKS = [
@@ -42,7 +42,7 @@ export const getIconVariant = (networkId: string): 'mono' | 'branded' => {
 }
 
 // Suport level for services
-export const getSubgraphsSupportLevel = (network: any): 'none' | 'basic' | 'full' => {
+export const getSubgraphsSupportLevel = (network: Network): 'none' | 'basic' | 'full' => {
   const hasSubgraphs = Boolean(network.services.subgraphs?.length || network.services.sps?.length)
 
   if (!hasSubgraphs) return 'none'
@@ -50,14 +50,14 @@ export const getSubgraphsSupportLevel = (network: any): 'none' | 'basic' | 'full
   return 'basic'
 }
 
-export const getSubstreamsSupportLevel = (network: any): 'none' | 'basic' | 'full' => {
+export const getSubstreamsSupportLevel = (network: Network): 'none' | 'basic' | 'full' => {
   const substreamCount = network.services.substreams?.length || 0
   if (substreamCount === 0) return 'none'
   if (substreamCount >= 2) return 'full'
   return 'basic'
 }
 
-export const getFirehoseSupportLevel = (network: any): 'none' | 'basic' | 'full' => {
+export const getFirehoseSupportLevel = (network: Network): 'none' | 'basic' | 'full' => {
   const firehoseCount = network.services.firehose?.length || 0
   if (firehoseCount === 0) return 'none'
   if (firehoseCount >= 2) return 'full'

--- a/website/src/supportedNetworks/utils.ts
+++ b/website/src/supportedNetworks/utils.ts
@@ -1,4 +1,4 @@
-import { NetworksRegistry, type Network } from '@pinax/graph-networks-registry'
+import { type Network,NetworksRegistry } from '@pinax/graph-networks-registry'
 
 // Networks that should use the "mono" icon variant (TODO: add this feature to web3icons?)
 export const MONO_ICON_NETWORKS = [
@@ -46,7 +46,7 @@ export const getSubgraphsSupportLevel = (network: Network): 'none' | 'basic' | '
   const hasSubgraphs = Boolean(network.services.subgraphs?.length || network.services.sps?.length)
 
   if (!hasSubgraphs) return 'none'
-  if (network.issuanceRewards === true) return 'full'
+  if (network.issuanceRewards) return 'full'
   return 'basic'
 }
 

--- a/website/src/supportedNetworks/utils.ts
+++ b/website/src/supportedNetworks/utils.ts
@@ -1,4 +1,4 @@
-import { type Network,NetworksRegistry } from '@pinax/graph-networks-registry'
+import { type Network, NetworksRegistry } from '@pinax/graph-networks-registry'
 
 // Networks that should use the "mono" icon variant (TODO: add this feature to web3icons?)
 export const MONO_ICON_NETWORKS = [

--- a/website/src/supportedNetworks/utils.ts
+++ b/website/src/supportedNetworks/utils.ts
@@ -41,6 +41,29 @@ export const getIconVariant = (networkId: string): 'mono' | 'branded' => {
   return MONO_ICON_NETWORKS.includes(networkId) ? 'mono' : 'branded'
 }
 
+// Suport level for services
+export const getSubgraphsSupportLevel = (network: any): 'none' | 'basic' | 'full' => {
+  const hasSubgraphs = Boolean(network.services.subgraphs?.length || network.services.sps?.length)
+
+  if (!hasSubgraphs) return 'none'
+  if (network.issuanceRewards === true) return 'full'
+  return 'basic'
+}
+
+export const getSubstreamsSupportLevel = (network: any): 'none' | 'basic' | 'full' => {
+  const substreamCount = network.services.substreams?.length || 0
+  if (substreamCount === 0) return 'none'
+  if (substreamCount >= 2) return 'full'
+  return 'basic'
+}
+
+export const getFirehoseSupportLevel = (network: any): 'none' | 'basic' | 'full' => {
+  const firehoseCount = network.services.firehose?.length || 0
+  if (firehoseCount === 0) return 'none'
+  if (firehoseCount >= 2) return 'full'
+  return 'basic'
+}
+
 export async function getSupportedNetworks() {
   const registry = await NetworksRegistry.fromLatestVersion()
   return registry.networks
@@ -61,6 +84,10 @@ export async function getSupportedNetworks() {
           substreams,
           firehose,
           tokenApi,
+          rawNetwork: network,
+          subgraphsSupportLevel: getSubgraphsSupportLevel(network),
+          substreamsSupportLevel: getSubstreamsSupportLevel(network),
+          firehoseSupportLevel: getFirehoseSupportLevel(network),
         },
       ]
     })

--- a/website/src/supportedNetworks/utils.ts
+++ b/website/src/supportedNetworks/utils.ts
@@ -41,23 +41,20 @@ export const getIconVariant = (networkId: string): 'mono' | 'branded' => {
   return MONO_ICON_NETWORKS.includes(networkId) ? 'mono' : 'branded'
 }
 
-// Suport level for services
-export const getSubgraphsSupportLevel = (network: Network): 'none' | 'basic' | 'full' => {
+// Support level for services
+export const getSubgraphsSupportLevel = (network: Network) => {
   const hasSubgraphs = Boolean(network.services.subgraphs?.length || network.services.sps?.length)
-
   if (!hasSubgraphs) return 'none'
   if (network.issuanceRewards) return 'full'
   return 'basic'
 }
-
-export const getSubstreamsSupportLevel = (network: Network): 'none' | 'basic' | 'full' => {
+export const getSubstreamsSupportLevel = (network: Network) => {
   const substreamCount = network.services.substreams?.length || 0
   if (substreamCount === 0) return 'none'
   if (substreamCount >= 2) return 'full'
   return 'basic'
 }
-
-export const getFirehoseSupportLevel = (network: Network): 'none' | 'basic' | 'full' => {
+export const getFirehoseSupportLevel = (network: Network) => {
   const firehoseCount = network.services.firehose?.length || 0
   if (firehoseCount === 0) return 'none'
   if (firehoseCount >= 2) return 'full'


### PR DESCRIPTION
Implements logic to display Check vs double check icons in `NetworksTable` based on service support levels from network registry

<img width="1879" alt="image" src="https://github.com/user-attachments/assets/e87b692c-6c40-4c1b-bf8e-c7864798a45b" />
