### PR TITLE
extra word removed from quick-start.mdx

### DIFF
--- a/website/src/pages/en/subgraphs/quick-start.mdx
+++ b/website/src/pages/en/subgraphs/quick-start.mdx
@@ -119,7 +119,7 @@ If you’d like to test your Subgraph before publishing it, you can use [Subgrap
 
 When your Subgraph is ready for a production environment, you can publish it to the decentralized network. Publishing is an onchain action that does the following:
 
-- It makes your Subgraph available to be to indexed by the decentralized [Indexers](/indexing/overview/) on The Graph Network.
+- It makes your Subgraph available to be indexed by the decentralized [Indexers](/indexing/overview/) on The Graph Network.
 - It removes rate limits and makes your Subgraph publicly searchable and queryable in [Graph Explorer](https://thegraph.com/explorer/).
 - It makes your Subgraph available for [Curators](/resources/roles/curating/) to add curation signal.
 


### PR DESCRIPTION
'It makes your Subgraph available to be to indexed...'  changed to
'It makes your Subgraph available to be indexed'