### PR TITLE
OpenAPI: only select the first `enum` value if the param is required

### DIFF
--- a/website/src/layout/templates/openApi/OpenApiContext.tsx
+++ b/website/src/layout/templates/openApi/OpenApiContext.tsx
@@ -42,7 +42,7 @@ export function OpenApiProvider({ api, operation, securitySchemes, children }: O
                 ? parameter.schema.default
                 : 'example' in parameter.schema
                   ? parameter.schema.example
-                  : 'enum' in parameter.schema && parameter.schema.enum?.length
+                  : 'enum' in parameter.schema && parameter.schema.enum?.length && parameter.required
                     ? parameter.schema.enum[0]
                     : undefined
             const initialValue: ParameterValue =


### PR DESCRIPTION
See [this Slack message](https://graphprotocol.slack.com/archives/C08AY2V7RTP/p1752190721905869?thread_ts=1752157189.388009&cid=C08AY2V7RTP) and the following ones.