### PR TITLE
Token API: updated FAQ wording, updated DEX section, adjusted upgrade v1 notes

### DIFF
--- a/website/src/pages/en/token-api/evm-nfts/collections.mdx
+++ b/website/src/pages/en/token-api/evm-nfts/collections.mdx
@@ -12,5 +12,5 @@ The `spam_status` flag indicates if the NFT is likely spam. If status shows `pen
 
 Spam detection is supported for:
 
-- mainnet
-- base
+- Ethereum Mainnet
+- Base Mainnet

--- a/website/src/pages/en/token-api/evm-nfts/collections.mdx
+++ b/website/src/pages/en/token-api/evm-nfts/collections.mdx
@@ -12,5 +12,10 @@ The `spam_status` flag indicates if the NFT is likely spam. If status shows `pen
 
 Spam detection is supported for:
 
-- Ethereum Mainnet
+- Arbitrum One
+- Avalanche C-Chain
 - Base Mainnet
+- BSC Mainnet
+- Ethereum Mainnet
+- Optimism Mainnet
+- Polygon Mainnet

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -9,7 +9,7 @@ Get fast answers to easily integrate and scale with The Graph's high-performance
 
 ### Which blockchains are supported by the Token API?
 
-Currently, the Token API supports Ethereum Mainnet, BNB Smart Chain (BSC Mainnet), Polygon Mainnet, Optimism Mainnet, Base Mainnet, Unichain Mainnet, Avalanche C-Chain, Arbitrum One, and Solana Mainnet. A full list of supported networks can be found under the Token API column [here](/supported-networks/).
+Currently, the Token API supports Ethereum Mainnet, BNB Smart Chain (BSC Mainnet), Polygon Mainnet, Optimism Mainnet, Base Mainnet, Unichain Mainnet, Avalanche C-Chain, Arbitrum One, Solana Mainnet and Tron Mainnet. A full list of supported networks can be found under the Token API column [here](/supported-networks/).
 
 ### Does the Token API support NFTs?
 
@@ -29,15 +29,11 @@ The API provides data up to the latest finalized block. This time varies dependi
 
 ### How do I retrieve token prices?
 
-Token prices are available with the Open-High-Low-Close (OHLC) endpoints. For a given time period, `"open"` represents the price at the start of the time period, `"high"` represents the highest price during the time period, `"low"` represents the lowest price, and `"close"` represents the price at the end of the time period.
+Token prices are available with the Open-High-Low-Close (OHLC) endpoints. For a given time period, `"open"` represents the price at the start of the time period, `"high"` represents the highest price during the time period, `"low"` represents the lowest price, and `"close"` represents the price at the end of the time period. You can change the time period using the `interval` parameter. Smaller time intervals are available on paid plans.
 
 ### Does the Token API support historical token data?
 
 The Token API supports historical token balances with the `/v1/evm/balances/historical` endpoint. You can query historical price data by pool at `/v1/evm/pools/ohlc`. Historical balances have a similar OHLC format, but return token balances instead of prices.
-
-### What exchanges does the Token API use for token prices?
-
-The Token API currently tracks prices on Uniswap v2, v3, and v4, along with Jupiter, Raydium, and Pump.fun on Solana, with plans to support additional exchanges in the future.
 
 ### Does the Token API provide a client SDK or client library?
 
@@ -301,7 +297,7 @@ NFT collections on supported chains contain a spam status field indicating wheth
 
 ### How do I retrieve the spam status for a collection?
 
-See the spam_status field on the [`/v1/evm/nft/collections/{contract}`](/token-api/evm-nfts/collections/) endpoint.
+See the spam_status field on the [`/v1/evm/nft/collections/{contract}`](/token-api/evm/get-nft-collections-evm-by-contract/) endpoint.
 
 ### Why am I seeing "pending" spam status?
 
@@ -363,9 +359,9 @@ To query Solana Mainnet, use the SVM endpoints.
 
 ### Why do I only see 10 results? How can I get more data?
 
-Endpoints cap output at 10 items by default. Use pagination parameters: `limit` and `page` (1-indexed) to return more results. For example, set `limit=50` to get 50 results, and increment `page` for subsequent batches (e.g., `page=2` for items 51-100).
+Endpoints cap output at 10 items by default. Use pagination parameters: `limit` and `page` (1-indexed) to return more results. For example, set `limit=10` to get 10 results (higher limits are available on paid plans), and increment `page` for subsequent batches (e.g., `page=2` for items 11-20).
 
-It is currently possible for the total number of pages to be inexact. This is because the backend provides only an approximation of the number of records in order to improve response time. To avoid getting confused by this approximation, make sure to continue fetching next pages until there is no more data, or the endpoint returns an error.
+To ensure you retrieve all data, continue fetching pages until the API returns an empty data array, indicating there is no more data.
 
 ### How do I fetch older transfer history?
 

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -297,7 +297,7 @@ NFT collections on supported chains contain a spam status field indicating wheth
 
 ### How do I retrieve the spam status for a collection?
 
-See the spam_status field on the [`/v1/evm/nft/collections/{contract}`](/token-api/evm/get-nft-collections-evm-by-contract/) endpoint.
+See the spam_status field on the [`/v1/evm/nft/collections/`](/token-api/evm-nfts/collections/) endpoint.
 
 ### Why am I seeing "pending" spam status?
 
@@ -305,7 +305,7 @@ There are millions of collections and we only analyze for spam on demand. If you
 
 ### What chains contain NFT spam detection?
 
-Spam detection is currently supported for the following chains:
+NFT spam detection is currently supported for the following chains:
 
 - Arbitrum One
 - Avalanche C-Chain

--- a/website/src/pages/en/token-api/quick-start.mdx
+++ b/website/src/pages/en/token-api/quick-start.mdx
@@ -15,7 +15,7 @@ The Token API provides access to onchain NFT and fungible token data, including 
 
 ## Prerequisites
 
-Before you begin, get a JWT API token by signing up on [The Graph Market](https://thegraph.market/). Make sure to use the JWT API Token, not the API key. Each API key can generate a new JWT API Token at any time.
+Before you begin, get a JWT API token by signing up on [The Graph Market](https://thegraph.market/plans/token-api/2025/). Make sure to use the JWT API Token, not the API key. Each API key can generate a new JWT API Token at any time.
 
 ## Authentication
 

--- a/website/src/pages/en/token-api/upgrade-to-v1.mdx
+++ b/website/src/pages/en/token-api/upgrade-to-v1.mdx
@@ -337,7 +337,7 @@ GET /v1/evm/transfers?network=mainnet&from_address=0xabc...,0xdef...,0x123...&st
 
 ## ⚠️ Important Notes
 
-1. **Backward Compatibility:** The old endpoints are deprecated and will be removed in the future. Migrate by **Oct 30, 2025**.
+1. **Migration Notes:** The old endpoints were deprecated and removed on **October 30, 2025**. Please ensure all integrations have been migrated to the new Token API v1 endpoints.
 
 2. **Default Sorting:** All results are now sorted by timestamp (descending) by default. Custom sorting is no longer supported.
 


### PR DESCRIPTION
-Added tron on Which blockchains are supported by the Token API? section
-On Why do I only see 10 results? How can I get more data? section, changed limit from 50 to 10, also modified context
-Removed What exchanges does the Token API use for token prices? section
-Quick start page on the Prerequisite section, sign up link redirects to https://thegraph.market/plans/token-api/2025/ (was https://thegraph.market/)
-Upgrade to v1 section changed Backward compatibility to past tense (**Migration Notes:**)