### PR TITLE
Update Token API MCP documentation

### DIFF
--- a/website/src/pages/en/ai-suite/token-api-mcp/claude.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/claude.mdx
@@ -19,6 +19,7 @@ Create or edit your `claude_desktop_config.json` file.
 - Linux: `.config/Claude/claude_desktop_config.json`
 
 **REST-based MCP**
+
 ```json label="claude_desktop_config.json"
 {
   "mcpServers": {
@@ -34,6 +35,7 @@ Create or edit your `claude_desktop_config.json` file.
 ```
 
 **SQL-based MCP**
+
 ```json label="claude_desktop_config.json"
 {
   "mcpServers": {
@@ -48,8 +50,7 @@ Create or edit your `claude_desktop_config.json` file.
 }
 ```
 
-> [!NOTE]
-> The previous `--sse-url` option is deprecated, use `--remote-url`.
+> [!NOTE] The previous `--sse-url` option is deprecated, use `--remote-url`.
 
 ## Troubleshooting
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/claude.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/claude.mdx
@@ -69,7 +69,7 @@ To enable logs for troubleshooting the MCP, add the option `"--verbose", "true"`
 }
 ```
 
-Logs are available under `logs/mcp.log` and `/logs/mcp-server-token-api.log` inside the folder of your Claude configuration file.
+Logs are available under `logs/mcp.log` and `logs/mcp-server-token-api.log` inside the folder of your Claude configuration file.
 
 ### ENOENT
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/claude.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/claude.mdx
@@ -18,12 +18,13 @@ Create or edit your `claude_desktop_config.json` file.
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 - Linux: `.config/Claude/claude_desktop_config.json`
 
+**REST-based MCP**
 ```json label="claude_desktop_config.json"
 {
   "mcpServers": {
     "token-api": {
       "command": "npx",
-      "args": ["@pinax/mcp", "--sse-url", "https://token-api.mcp.thegraph.com/sse"],
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/"],
       "env": {
         "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
       }
@@ -32,9 +33,43 @@ Create or edit your `claude_desktop_config.json` file.
 }
 ```
 
+**SQL-based MCP**
+```json label="claude_desktop_config.json"
+{
+  "mcpServers": {
+    "token-api": {
+      "command": "npx",
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/sql"],
+      "env": {
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> The previous `--sse-url` option is deprecated, use `--remote-url`.
+
 ## Troubleshooting
 
-To enable logs for the MCP, add the option `"--verbose", "true"` under `"args"`.
+To enable logs for troubleshooting the MCP, add the option `"--verbose", "true"` under `"args"`.
+
+```json label="claude_desktop_config.json"
+{
+  "mcpServers": {
+    "token-api": {
+      "command": "npx",
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/", "--verbose", "true"],
+      "env": {
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
+      }
+    }
+  }
+}
+```
+
+Logs are available under `logs/mcp.log` and `/logs/mcp-server-token-api.log` inside the folder of your Claude configuration file.
 
 ### ENOENT
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/cline.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/cline.mdx
@@ -19,6 +19,7 @@ Create or edit your `cline_mcp_settings.json` file.
 > **MCP Servers** > **Installed** > **Configure MCP Servers**
 
 **REST-based MCP**
+
 ```json label="cline_mcp_settings.json"
 {
   "mcpServers": {
@@ -34,6 +35,7 @@ Create or edit your `cline_mcp_settings.json` file.
 ```
 
 **SQL-based MCP**
+
 ```json label="cline_mcp_settings.json"
 {
   "mcpServers": {
@@ -48,8 +50,7 @@ Create or edit your `cline_mcp_settings.json` file.
 }
 ```
 
-> [!NOTE]
-> The previous `--sse-url` option is deprecated, use `--remote-url`.
+> [!NOTE] The previous `--sse-url` option is deprecated, use `--remote-url`.
 
 ## Troubleshooting
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/cline.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/cline.mdx
@@ -18,23 +18,56 @@ Create or edit your `cline_mcp_settings.json` file.
 
 > **MCP Servers** > **Installed** > **Configure MCP Servers**
 
+**REST-based MCP**
 ```json label="cline_mcp_settings.json"
 {
   "mcpServers": {
-    "mcp-pinax": {
+    "token-api": {
       "command": "npx",
-      "args": ["@pinax/mcp", "--sse-url", "https://token-api.mcp.thegraph.com/sse"],
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/"],
       "env": {
-        "ACCESS_TOKEN": "<JWT Token from thegraph.market>"
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
       }
     }
   }
 }
 ```
 
+**SQL-based MCP**
+```json label="cline_mcp_settings.json"
+{
+  "mcpServers": {
+    "token-api": {
+      "command": "npx",
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/sql"],
+      "env": {
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> The previous `--sse-url` option is deprecated, use `--remote-url`.
+
 ## Troubleshooting
 
 To enable logs for the MCP, use the `--verbose true` option.
+
+```json label="cline_mcp_settings.json"
+{
+  "mcpServers": {
+    "token-api": {
+      "command": "npx",
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/", "--verbose", "true"],
+      "env": {
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
+      }
+    }
+  }
+}
+```
 
 ### ENOENT
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/cursor.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/cursor.mdx
@@ -18,14 +18,30 @@ Create or edit your `~/.cursor/mcp.json` file.
 
 > **Cursor Settings** > **MCP** > **Add new global MCP Server**
 
+**REST-based MCP**
 ```json label="mcp.json"
 {
   "mcpServers": {
-    "mcp-pinax": {
+    "token-api": {
       "command": "npx",
-      "args": ["@pinax/mcp", "--sse-url", "https://token-api.mcp.thegraph.com/sse"],
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/"],
       "env": {
-        "ACCESS_TOKEN": "<JWT Token from thegraph.market>"
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
+      }
+    }
+  }
+}
+```
+
+**SQL-based MCP**
+```json label="mcp.json"
+{
+  "mcpServers": {
+    "token-api": {
+      "command": "npx",
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/sql"],
+      "env": {
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
       }
     }
   }
@@ -37,6 +53,20 @@ Create or edit your `~/.cursor/mcp.json` file.
 ![Cursor IDE error notification that reads, "Failed to create client"](/img/cursor-error.png)
 
 To enable logs for the MCP, use the `--verbose true` option.
+
+```json label="mcp.json"
+{
+  "mcpServers": {
+    "token-api": {
+      "command": "npx",
+      "args": ["@pinax/mcp", "--remote-url", "https://token-api.mcp.thegraph.com/", "--verbose", "true"],
+      "env": {
+        "ACCESS_TOKEN": "<https://thegraph.market JWT Access Token>"
+      }
+    }
+  }
+}
+```
 
 ### ENOENT
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/cursor.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/cursor.mdx
@@ -19,6 +19,7 @@ Create or edit your `~/.cursor/mcp.json` file.
 > **Cursor Settings** > **MCP** > **Add new global MCP Server**
 
 **REST-based MCP**
+
 ```json label="mcp.json"
 {
   "mcpServers": {
@@ -34,6 +35,7 @@ Create or edit your `~/.cursor/mcp.json` file.
 ```
 
 **SQL-based MCP**
+
 ```json label="mcp.json"
 {
   "mcpServers": {

--- a/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
@@ -5,11 +5,15 @@ sidebarTitle: 'Introduction'
 
 Token API MCP server is an open-source implementation of [Anthropic's Model Context Protocol](https://modelcontextprotocol.io/introduction).
 
-This MCP server makes on-chain token data, including metadata, balances, transfers, and holder statistics, accessible through a set of MCP tools. Any compatible client can use these tools to fetch and analyze token information through a standardized interface. It connects to The Graph's hosted Token API database, enabling AI assistants to query real-time blockchain data using natural language requests that get translated into optimized SQL queries.
+This MCP server makes on-chain token data, including metadata, balances, transfers, and holder statistics, accessible through a set of MCP tools. Any compatible client can use these tools to fetch and analyze token information through a standardized interface. It connects to The Graph's hosted Token API database, enabling AI assistants to query blockchain data using natural language requests.
 
-The server itself does not host any language model. It simply converts MCP calls into data look-ups and returns structured results, letting the client's own LLM incorporate the results.
+There are two types of MCP available for use:
+- A REST-based MCP, the default, that communicates with the Token API.
+- A SQL-based MCP, for advanced users, that allows for communicating with the backend databases that powers the Token API.
 
-Think of it as a USB-C hub: it standardizes the plug-and-play connection between AI agents and The Graph's Token API data.
+The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It automatically stays up-to-date with new Token API releases so you don't miss any new features !
+
+The SQL-based MCP provides the LLM tools to list databases and tables as well as run SQL queries directly on the data. It is meant for advanced users who need different use cases that the standard API endpoints cannot replicate. For best results, it is advised to use an LLM model specifically tuned for working with SQL.
 
 ## What You Can Do
 
@@ -20,4 +24,4 @@ Think of it as a USB-C hub: it standardizes the plug-and-play connection between
 - Ask natural language questions about token data without writing smart contract calls
 - Access historical transfer data to analyze token movement over time
 
-The Token MCP server provides [Claude](/ai-suite/token-api-mcp/claude/), [Cline](/ai-suite/token-api-mcp/cline/), and [Cursor](/ai-suite/token-api-mcp/cursor/) with direct, conversational access to onchain token data.
+The Token MCP server provides [Claude](/ai-suite/token-api-mcp/claude/), [Cline](/ai-suite/token-api-mcp/cline/), [Cursor](/ai-suite/token-api-mcp/cursor/) and any other client with MCP integration a direct, conversational access to onchain token data.

--- a/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
@@ -8,10 +8,11 @@ Token API MCP server is an open-source implementation of [Anthropic's Model Cont
 This MCP server makes on-chain token data, including metadata, balances, transfers, and holder statistics, accessible through a set of MCP tools. Any compatible client can use these tools to fetch and analyze token information through a standardized interface. It connects to The Graph's hosted Token API database, enabling AI assistants to query blockchain data using natural language requests.
 
 There are two types of MCP available for use:
+
 - A REST-based MCP, the default, that communicates with the Token API.
 - A SQL-based MCP, for advanced users, that allows for communicating with the backend databases that power the Token API.
 
-The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It is the *recommended way* to set up an LLM with Token API as the set of tools it offers is straightforward to use for any language model. Additionnaly, it automatically stays up-to-date with new Token API releases so you don't miss any new features!
+The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It is the _recommended way_ to set up an LLM with Token API as the set of tools it offers is straightforward to use for any language model. Additionnaly, it automatically stays up-to-date with new Token API releases so you don't miss any new features!
 
 The SQL-based MCP provides the LLM tools to list databases and tables as well as run SQL queries directly on the data. It is meant for advanced users who need different use cases that the standard API endpoints cannot replicate. For best results, it is advised to use an LLM model specifically tuned for working with SQL as general purpose LLMs models (like Sonnet, Gemini, etc.) might not be able to generate valid queries efficiently.
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
@@ -9,7 +9,7 @@ This MCP server makes on-chain token data, including metadata, balances, transfe
 
 There are two types of MCP available for use:
 - A REST-based MCP, the default, that communicates with the Token API.
-- A SQL-based MCP, for advanced users, that allows for communicating with the backend databases that powers the Token API.
+- A SQL-based MCP, for advanced users, that allows for communicating with the backend databases that power the Token API.
 
 The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It is the *recommended way* to setup an LLM with Token API as the set of tools it offers is straightforward to use for any language model. Additionnaly, it automatically stays up-to-date with new Token API releases so you don't miss any new features !
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
@@ -11,7 +11,7 @@ There are two types of MCP available for use:
 - A REST-based MCP, the default, that communicates with the Token API.
 - A SQL-based MCP, for advanced users, that allows for communicating with the backend databases that power the Token API.
 
-The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It is the *recommended way* to setup an LLM with Token API as the set of tools it offers is straightforward to use for any language model. Additionnaly, it automatically stays up-to-date with new Token API releases so you don't miss any new features !
+The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It is the *recommended way* to set up an LLM with Token API as the set of tools it offers is straightforward to use for any language model. Additionnaly, it automatically stays up-to-date with new Token API releases so you don't miss any new features!
 
 The SQL-based MCP provides the LLM tools to list databases and tables as well as run SQL queries directly on the data. It is meant for advanced users who need different use cases that the standard API endpoints cannot replicate. For best results, it is advised to use an LLM model specifically tuned for working with SQL as general purpose LLMs models (like Sonnet, Gemini, etc.) might not be able to generate valid queries efficiently.
 

--- a/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
+++ b/website/src/pages/en/ai-suite/token-api-mcp/introduction.mdx
@@ -11,9 +11,9 @@ There are two types of MCP available for use:
 - A REST-based MCP, the default, that communicates with the Token API.
 - A SQL-based MCP, for advanced users, that allows for communicating with the backend databases that powers the Token API.
 
-The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It automatically stays up-to-date with new Token API releases so you don't miss any new features !
+The REST-based MCP simply exposes the API endpoints to your LLM based on the OpenAPI specification (available at https://token-api.thegraph.com/openapi). It is the *recommended way* to setup an LLM with Token API as the set of tools it offers is straightforward to use for any language model. Additionnaly, it automatically stays up-to-date with new Token API releases so you don't miss any new features !
 
-The SQL-based MCP provides the LLM tools to list databases and tables as well as run SQL queries directly on the data. It is meant for advanced users who need different use cases that the standard API endpoints cannot replicate. For best results, it is advised to use an LLM model specifically tuned for working with SQL.
+The SQL-based MCP provides the LLM tools to list databases and tables as well as run SQL queries directly on the data. It is meant for advanced users who need different use cases that the standard API endpoints cannot replicate. For best results, it is advised to use an LLM model specifically tuned for working with SQL as general purpose LLMs models (like Sonnet, Gemini, etc.) might not be able to generate valid queries efficiently.
 
 ## What You Can Do
 

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -283,11 +283,25 @@ You can find the code for the MCP client in [The Graph's repo](https://github.co
 
 ### MCP integration with Claude/Cline/Cursor shows errors like "ENOENT" or "Server disconnected". How do I fix this?
 
-For "ENOENT" errors, ensure Node.js 18+ is installed and the path to `npx`/`bunx` is correct (consider using full paths in config). "Server disconnected" usually indicates authentication or connectivity issues – verify your `ACCESS_TOKEN` is set correctly and your network allows access to `https://token-api.mcp.thegraph.com/sse`.
+For "ENOENT" errors, ensure Node.js 18+ is installed and the path to `npx`/`bunx` is correct (consider using full paths in config). "Server disconnected" usually indicates authentication or connectivity issues – verify your `ACCESS_TOKEN` is set correctly and your network allows access to `https://token-api.mcp.thegraph.com/`.
 
 ### Do I need to use MCP or tools like Claude, Cline, or Cursor?
 
 No, these are optional. MCP is an advanced feature allowing AI assistants to interface with the API via streaming. For standard usage, simply call the REST endpoints with any HTTP client using your JWT. Claude Desktop, Cline bot, and Cursor IDE integrations are provided for convenience but aren't required.
+
+### How do I choose between the REST-MCP and the SQL-MCP and which one should I use ?
+
+To use one or the other, you need to supply the adequate URL in your configuration file (see the [docs](https://thegraph.com/docs/en/ai-suite/token-api-mcp/introduction/) for how to setup your configuration):
+- `https://token-api.mcp.thegraph.com/` is for the REST-MCP
+- `https://token-api.mcp.thegraph.com/sql` is for the SQL-MCP
+
+Which one you'll want to use depends on your use cases. Most of the time you should use the REST-MCP as it's the simplest way for the LLM to interact with blockchain data from the Token API. If you want answers to basic questions such as `What is the balance of ...`, `How many holders of ...`, etc. the REST-MCP gives your LLM all the tools it needs.
+
+The SQL-MCP should be used in an analyst use case where complex aggregations are needed that the Token API doesn't provide on its endpoints. It will require the LLM to discover and craft working SQL queries on the backend databases of the Token API.
+
+### Will using the REST-MCP counts towards my Token API usage ?
+
+Yes, you need to provide your Token API token to the MCP for authenticating with the Token API. The MCP makes API requests on your behalf when your LLM interacts with it.
 
 ## NFT Spam Detection
 

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -292,6 +292,7 @@ No, these are optional. MCP is an advanced feature allowing AI assistants to int
 ### How do I choose between the REST-MCP and the SQL-MCP and which one should I use?
 
 To use one or the other, you need to supply the adequate URL in your configuration file (see the [docs](https://thegraph.com/docs/en/ai-suite/token-api-mcp/introduction/) for how to set up your configuration):
+
 - `https://token-api.mcp.thegraph.com/` is for the REST-MCP
 - `https://token-api.mcp.thegraph.com/sql` is for the SQL-MCP
 

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -291,7 +291,7 @@ No, these are optional. MCP is an advanced feature allowing AI assistants to int
 
 ### How do I choose between the REST-MCP and the SQL-MCP and which one should I use?
 
-To use one or the other, you need to supply the adequate URL in your configuration file (see the [docs](https://thegraph.com/docs/en/ai-suite/token-api-mcp/introduction/) for how to setup your configuration):
+To use one or the other, you need to supply the adequate URL in your configuration file (see the [docs](https://thegraph.com/docs/en/ai-suite/token-api-mcp/introduction/) for how to set up your configuration):
 - `https://token-api.mcp.thegraph.com/` is for the REST-MCP
 - `https://token-api.mcp.thegraph.com/sql` is for the SQL-MCP
 

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -299,7 +299,7 @@ Which one you'll want to use depends on your use cases. Most of the time you sho
 
 The SQL-MCP should be used in an analyst use case where complex aggregations are needed that the Token API doesn't provide on its endpoints. It will require the LLM to discover and craft working SQL queries on the backend databases of the Token API.
 
-### Will using the REST-MCP counts towards my Token API usage ?
+### Will using the REST-MCP counts towards my Token API usage?
 
 Yes, you need to provide your Token API token to the MCP for authenticating with the Token API. The MCP makes API requests on your behalf when your LLM interacts with it.
 

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -289,7 +289,7 @@ For "ENOENT" errors, ensure Node.js 18+ is installed and the path to `npx`/`bunx
 
 No, these are optional. MCP is an advanced feature allowing AI assistants to interface with the API via streaming. For standard usage, simply call the REST endpoints with any HTTP client using your JWT. Claude Desktop, Cline bot, and Cursor IDE integrations are provided for convenience but aren't required.
 
-### How do I choose between the REST-MCP and the SQL-MCP and which one should I use ?
+### How do I choose between the REST-MCP and the SQL-MCP and which one should I use?
 
 To use one or the other, you need to supply the adequate URL in your configuration file (see the [docs](https://thegraph.com/docs/en/ai-suite/token-api-mcp/introduction/) for how to setup your configuration):
 - `https://token-api.mcp.thegraph.com/` is for the REST-MCP


### PR DESCRIPTION
**introduction.mdx**
- Adds the two types of MCP
- Emphasizes REST easier to use for LLMs than SQL 
- Misc editing

**claude.mdx**
- Adds REST MCP config
- Updates config commands
- Adds depreciation notice for `--sse-url` option
- Improves troubleshooting section

**cline.mdx**
Same as Claude

**cursor.mdx**
Same as Claude

**faq.mdx**
- Adds `How do I choose between the REST-MCP and the SQL-MCP and which one should I use ?`
- Adds `Will using the REST-MCP counts towards my Token API usage ?`