### PR TITLE
Update DEX listings and sort by swap volume, fixed chain names on Protocol Contracts page

### DIFF
--- a/website/src/pages/en/contracts.mdx
+++ b/website/src/pages/en/contracts.mdx
@@ -6,13 +6,13 @@ import { ProtocolContractsTable } from '@/contracts'
 
 Below are the deployed contracts which power The Graph Network. Visit the official [contracts repository](https://github.com/graphprotocol/contracts) to learn more.
 
-## Arbitrum
+## Arbitrum One
 
 This is the principal deployment of The Graph Network.
 
 <ProtocolContractsTable networkId={42161} />
 
-## Mainnet
+## Ethereum Mainnet
 
 This was the original deployment of The Graph Network. [Learn more](/archived/arbitrum/arbitrum-faq/) about The Graph's scaling with Arbitrum.
 

--- a/website/src/pages/en/token-api/faq.mdx
+++ b/website/src/pages/en/token-api/faq.mdx
@@ -131,8 +131,12 @@ Swaps are being reported via Aggregator programs and do not include amm_pool fie
 
 - Uniswap V2
 - Uniswap V3
+- Uniswap V1
 - Uniswap V4
 - SushiSwap V2
+- Balancer
+- Curve
+- Bancor
 - Ring Swap
 - Shiba Inu
 - Crypto.com: DeFi Swap
@@ -159,6 +163,8 @@ Swaps are being reported via Aggregator programs and do not include amm_pool fie
 - Uniswap V3
 - Uniswap V4
 - SushiSwap V3
+- Balancer
+- Curve
 - Ramses
 - SushiSwap V2
 - Uniswap V2
@@ -181,6 +187,8 @@ Swaps are being reported via Aggregator programs and do not include amm_pool fie
 - Uniswap V4
 - SushiSwap V2
 - Uniswap V2
+- Balancer
+- Curve
 - Stabl.fi
 - SushiSwap V3
 - SweepnFlip
@@ -222,6 +230,7 @@ Swaps are being reported via Aggregator programs and do not include amm_pool fie
 - Uniswap V4
 - Velodrome V3
 - Velodrome V2
+- Balancer
 - Curve
 - Beethoven X
 
@@ -236,6 +245,7 @@ Swaps are being reported via Aggregator programs and do not include amm_pool fie
 - Uniswap V4
 - Lydia Finance
 - SushiSwap V2
+- Curve
 - OliveSwap
 
 #### Base Mainnet
@@ -244,6 +254,8 @@ Swaps are being reported via Aggregator programs and do not include amm_pool fie
 - Uniswap V2
 - Uniswap V4
 - SushiSwap V2
+- Balancer
+- Curve
 - BaseSwap
 - Alien Base V3
 - BaseSwap V2
@@ -252,9 +264,9 @@ Swaps are being reported via Aggregator programs and do not include amm_pool fie
 
 #### Tron Mainnet
 
-- SunSwap V1 (JustSwap)
-- SunSwap V2
 - SunPump
+- SunSwap V2
+- SunSwap V1 (JustSwap)
 - USwap
 - SunSwap 1.5 (JustSwap)
 - ISwap V1


### PR DESCRIPTION
 -fixed chain names on Protocol Contracts page (Arbitrum -> Arbitrum One)

 -added new EVM DEX's :
Uniswap V1
Cow Protocol (Aggregator)
Bancor
CurveFi
Balancer

-sorted Tron DEX's (the top three)