### PR TITLE
feat: add "Copy page" button for LLMs

### DIFF
--- a/website/src/components/CopyForLLM.tsx
+++ b/website/src/components/CopyForLLM.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface CopyForLLMProps {
+  /** URL to the raw Markdown source of this page */
+  rawUrl: string
+}
+
+/**
+ * A "Copy page" button with a dropdown that lets users:
+ * 1. Copy the page's raw Markdown to the clipboard (great for LLMs)
+ * 2. Open the raw Markdown in a new tab
+ */
+export function CopyForLLM({ rawUrl }: CopyForLLMProps) {
+  const [open, setOpen] = useState(false)
+  const [status, setStatus] = useState<'idle' | 'copying' | 'copied'>('idle')
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close the dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const copyMarkdown = async () => {
+    setOpen(false)
+    setStatus('copying')
+    try {
+      const res = await fetch(rawUrl)
+      const text = await res.text()
+      await navigator.clipboard.writeText(text)
+      setStatus('copied')
+      setTimeout(() => setStatus('idle'), 2000)
+    } catch {
+      setStatus('idle')
+    }
+  }
+
+  const label =
+    status === 'copied' ? 'Copied!' : status === 'copying' ? 'Copying…' : 'Copy page'
+
+  return (
+    <div ref={menuRef} className="relative flex items-center">
+      {/* Primary button */}
+      <button
+        onClick={copyMarkdown}
+        className="
+          flex items-center gap-1.5
+          rounded-s border border-space-1400
+          px-2.5 py-1
+          text-body-xsmall text-space-700
+          outline-offset-2 transition
+          hover:border-space-1200 hover:text-space-300
+        "
+      >
+        <ClipboardIcon />
+        {label}
+      </button>
+
+      {/* Chevron toggle */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="More options"
+        aria-expanded={open}
+        className="
+          flex items-center
+          rounded-e border border-s-0 border-space-1400
+          px-1.5 py-1
+          text-space-700
+          outline-offset-2 transition
+          hover:border-space-1200 hover:text-space-300
+        "
+      >
+        <ChevronIcon open={open} />
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div className="absolute end-0 top-full z-20 mt-1.5 w-64 overflow-hidden rounded border border-space-1400 bg-space-1700 shadow-lg">
+          <button
+            onClick={copyMarkdown}
+            className="flex w-full items-start gap-3 px-4 py-3 text-start transition hover:bg-space-1600"
+          >
+            <ClipboardIcon className="mt-0.5 shrink-0 text-space-500" size={16} />
+            <div>
+              <div className="text-body-small text-white">Copy page</div>
+              <div className="text-body-xsmall text-space-600">Copy page as Markdown for LLMs</div>
+            </div>
+          </button>
+
+          <a
+            href={rawUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+            className="flex items-start gap-3 px-4 py-3 transition hover:bg-space-1600"
+          >
+            <MarkdownIcon className="mt-0.5 shrink-0 text-space-500" />
+            <div>
+              <div className="text-body-small text-white">View as Markdown ↗</div>
+              <div className="text-body-xsmall text-space-600">View this page as plain text</div>
+            </div>
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Inline SVG icons (avoids adding an icon library dependency)
+// ---------------------------------------------------------------------------
+
+function ClipboardIcon({
+  className,
+  size = 14,
+}: {
+  className?: string
+  size?: number
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <rect x="9" y="2" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d={open ? 'M1 7l4-4 4 4' : 'M1 3l4 4 4-4'} />
+    </svg>
+  )
+}
+
+function MarkdownIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="16" y1="13" x2="8" y2="13" />
+      <line x1="16" y1="17" x2="8" y2="17" />
+      <polyline points="10 9 9 9 8 9" />
+    </svg>
+  )
+}

--- a/website/src/components/CopyForLLM.tsx
+++ b/website/src/components/CopyForLLM.tsx
@@ -40,19 +40,18 @@ export function CopyForLLM({ rawUrl }: CopyForLLMProps) {
     }
   }
 
-  const label =
-    status === 'copied' ? 'Copied!' : status === 'copying' ? 'Copying…' : 'Copy page'
+  const label = status === 'copied' ? 'Copied!' : status === 'copying' ? 'Copying…' : 'Copy page'
 
   return (
     <div ref={menuRef} className="relative flex items-center">
       {/* Primary button */}
       <button
-        onClick={copyMarkdown}
+        onClick={() => void copyMarkdown()}
         className="
-          flex items-center gap-1.5
-          rounded-s border border-space-1400
-          px-2.5 py-1
-          text-body-xsmall text-space-700
+          rounded-s text-body-xsmall flex
+          items-center gap-1.5 border
+          border-space-1400 px-2.5
+          py-1 text-space-700
           outline-offset-2 transition
           hover:border-space-1200 hover:text-space-300
         "
@@ -67,8 +66,8 @@ export function CopyForLLM({ rawUrl }: CopyForLLMProps) {
         aria-label="More options"
         aria-expanded={open}
         className="
-          flex items-center
-          rounded-e border border-s-0 border-space-1400
+          rounded-e flex
+          items-center border border-s-0 border-space-1400
           px-1.5 py-1
           text-space-700
           outline-offset-2 transition
@@ -80,9 +79,9 @@ export function CopyForLLM({ rawUrl }: CopyForLLMProps) {
 
       {/* Dropdown */}
       {open && (
-        <div className="absolute end-0 top-full z-20 mt-1.5 w-64 overflow-hidden rounded border border-space-1400 bg-space-1700 shadow-lg">
+        <div className="rounded absolute end-0 top-full z-20 mt-1.5 w-64 overflow-hidden border border-space-1400 bg-space-1700 shadow-lg">
           <button
-            onClick={copyMarkdown}
+            onClick={() => void copyMarkdown()}
             className="flex w-full items-start gap-3 px-4 py-3 text-start transition hover:bg-space-1600"
           >
             <ClipboardIcon className="mt-0.5 shrink-0 text-space-500" size={16} />
@@ -101,7 +100,7 @@ export function CopyForLLM({ rawUrl }: CopyForLLMProps) {
           >
             <MarkdownIcon className="mt-0.5 shrink-0 text-space-500" />
             <div>
-              <div className="text-body-small text-white">View as Markdown ↗</div>
+              <div className="text-body-small text-white">View as Markdown ↗</div>
               <div className="text-body-xsmall text-space-600">View this page as plain text</div>
             </div>
           </a>
@@ -115,13 +114,7 @@ export function CopyForLLM({ rawUrl }: CopyForLLMProps) {
 // Inline SVG icons (avoids adding an icon library dependency)
 // ---------------------------------------------------------------------------
 
-function ClipboardIcon({
-  className,
-  size = 14,
-}: {
-  className?: string
-  size?: number
-}) {
+function ClipboardIcon({ className, size = 14 }: { className?: string; size?: number }) {
   return (
     <svg
       width={size}

--- a/website/src/components/CopyForLLM.tsx
+++ b/website/src/components/CopyForLLM.tsx
@@ -1,5 +1,17 @@
 import { useEffect, useRef, useState } from 'react'
 
+/**
+ * Strip MDX-only noise (YAML frontmatter + `import` statements) so the copied
+ * text is clean Markdown an LLM can ingest directly, rather than raw page source.
+ */
+function cleanMdxForLLM(src: string): string {
+  return src
+    .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n+/, '') // drop YAML frontmatter
+    .replace(/^\s*import\s.+$/gm, '') // drop import statements
+    .replace(/\n{3,}/g, '\n\n') // collapse blank-line runs
+    .trim()
+}
+
 interface CopyForLLMProps {
   /** URL to the raw Markdown source of this page */
   rawUrl: string
@@ -31,7 +43,7 @@ export function CopyForLLM({ rawUrl }: CopyForLLMProps) {
     setStatus('copying')
     try {
       const res = await fetch(rawUrl)
-      const text = await res.text()
+      const text = cleanMdxForLLM(await res.text())
       await navigator.clipboard.writeText(text)
       setStatus('copied')
       setTimeout(() => setStatus('idle'), 2000)

--- a/website/src/components/index.ts
+++ b/website/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './Callout'
 export * from './Card'
 export * from './CodeBlock'
+export * from './CopyForLLM'
 export * from './DocSearch'
 export * from './Heading'
 export * from './Image'

--- a/website/src/layout/templates/default/content.tsx
+++ b/website/src/layout/templates/default/content.tsx
@@ -28,9 +28,7 @@ export default function TemplateDefaultContent({ className, children, ...props }
   // blob URL into a raw.githubusercontent.com URL.  For local pages, build
   // the raw URL from the file path.
   const rawMarkdownUrl = remotePageUrl
-    ? remotePageUrl
-        .replace('https://github.com/', 'https://raw.githubusercontent.com/')
-        .replace('/blob/', '/')
+    ? remotePageUrl.replace('https://github.com/', 'https://raw.githubusercontent.com/').replace('/blob/', '/')
     : (() => {
         const [_src, _pages, ...segments] = filePath.split('/')
         return `https://raw.githubusercontent.com/graphprotocol/docs/main/website/src/pages/${segments.join('/')}`

--- a/website/src/layout/templates/default/content.tsx
+++ b/website/src/layout/templates/default/content.tsx
@@ -3,6 +3,7 @@ import { type ComponentProps, useContext } from 'react'
 import { ButtonOrLink, classNames, ExperimentalDivider, ExperimentalLink } from '@edgeandnode/gds'
 import { ArrowLeft, ArrowRight, CalendarDynamic, HourglassDynamic, SocialGitHub } from '@edgeandnode/gds/icons'
 
+import { CopyForLLM } from '@/components'
 import { useI18n } from '@/i18n'
 
 import { LayoutContext } from '../../shared'
@@ -21,6 +22,19 @@ export default function TemplateDefaultContent({ className, children, ...props }
       const [_src, _pages, ...segments] = filePath.split('/')
       return `https://github.com/graphprotocol/docs/blob/main/website/src/pages/${segments.map(encodeURIComponent).join('/')}`
     })()
+
+  // Derive the raw Markdown URL so users can copy it directly into an LLM.
+  // For remote pages (e.g. sourced from another repo), transform the GitHub
+  // blob URL into a raw.githubusercontent.com URL.  For local pages, build
+  // the raw URL from the file path.
+  const rawMarkdownUrl = remotePageUrl
+    ? remotePageUrl
+        .replace('https://github.com/', 'https://raw.githubusercontent.com/')
+        .replace('/blob/', '/')
+    : (() => {
+        const [_src, _pages, ...segments] = filePath.split('/')
+        return `https://raw.githubusercontent.com/graphprotocol/docs/main/website/src/pages/${segments.join('/')}`
+      })()
 
   return (
     <div
@@ -68,7 +82,7 @@ export default function TemplateDefaultContent({ className, children, ...props }
           group-data-[unwrap-content]/layout-content-grid:grid
           group-data-[unwrap-content]/layout-content-grid:auto-rows-max
           group-data-[unwrap-content]/layout-content-grid:grid-cols-subgrid
-          ${/* The following allows one child to be full height by setting `row-[full]`; see https://codepen.io/benface/pen/PwoaKJg */ ''}
+          ${/* The following allows one child to be full height by setting \`row-[full]\`; see https://codepen.io/benface/pen/PwoaKJg */ ''}
           group-data-[unwrap-content]/layout-content-grid:grid-rows-[repeat(auto-fit,minmax(0,max-content))_[full]_minmax(0,1fr)]
           -:group-data-[unwrap-content]/layout-content-grid:*:col-span-full
           -:group-not-data-[hide-content-header]/layout-content-grid:first:*:mt-6
@@ -123,14 +137,17 @@ export default function TemplateDefaultContent({ className, children, ...props }
                 </time>
               </div>
             ) : null}
-            <ExperimentalLink
-              href={editPageUrl}
-              target="_blank"
-              iconBefore={<SocialGitHub alt="" />}
-              className="ms-auto text-space-700"
-            >
-              {t('global.page.edit')}
-            </ExperimentalLink>
+            <div className="ms-auto flex items-center gap-3">
+              <CopyForLLM rawUrl={rawMarkdownUrl} />
+              <ExperimentalLink
+                href={editPageUrl}
+                target="_blank"
+                iconBefore={<SocialGitHub alt="" />}
+                className="text-space-700"
+              >
+                {t('global.page.edit')}
+              </ExperimentalLink>
+            </div>
           </div>
           <ExperimentalDivider variant="subtle" />
           <div


### PR DESCRIPTION
## What

Adds a **"Copy page"** button to the footer of every documentation page, letting users copy the page's raw Markdown to their clipboard — ideal for pasting directly into LLMs like Claude or ChatGPT.

Inspired by Notion's "Copy for LLM" feature.

## How it works

- **Copy page** — fetches the raw `.mdx` source from GitHub and copies it to the clipboard as Markdown
- **View as Markdown ↗** — opens the raw GitHub file in a new tab

The button lives in `content.tsx` alongside the existing "Edit on GitHub" link, so it **automatically appears on all doc pages** without touching any individual `.mdx` files.

## Changes

| File | What changed |
|---|---|
| `website/src/components/CopyForLLM.tsx` | New component (button + dropdown) |
| `website/src/components/index.ts` | Export the new component |
| `website/src/layout/templates/default/content.tsx` | Derive `rawMarkdownUrl` and render `<CopyForLLM>` next to the edit link |

## Why this is useful

The Graph docs cover complex protocol concepts — subgraphs, indexing, query architecture, etc. Developers frequently paste doc pages into LLMs to ask follow-up questions. This button removes the friction of manually copying, and since the source is already Markdown, no conversion is needed.

## Screenshot / mockup

The button appears at the bottom of every page, to the left of "Edit on GitHub":

```
[last updated date]          [Copy page ▾]  [✎ Edit this page]
```

Clicking "Copy page" copies the full Markdown source. The dropdown also exposes "View as Markdown ↗" for a direct link to the raw file.
