### PR TITLE
fix: update Large hardware tier description to reflect current network scale

### DIFF
--- a/website/src/pages/en/indexing/overview.mdx
+++ b/website/src/pages/en/indexing/overview.mdx
@@ -126,7 +126,7 @@ Indexers may differentiate themselves by applying advanced techniques for making
 - **Small** - Enough to get started indexing several Subgraphs, will likely need to be expanded.
 - **Standard** - Default setup, this is what is used in the example k8s/terraform deployment manifests.
 - **Medium** - Production Indexer supporting 100 Subgraphs and 200-500 requests per second.
-- **Large** - Prepared to index all currently used Subgraphs and serve requests for the related traffic.
+- **Large** - Sufficient for approximately 1,500–2,000 Subgraphs. Note: these figures predate significant network growth. As of 2026, the network has over 15,000 Subgraphs; community operators report ~600 GB total RAM for ~1,700 Subgraphs. Indexing the full network requires substantially more resources than this tier provides.
 
 | Setup | Postgres<br />(CPUs) | Postgres<br />(memory in GBs) | Postgres<br />(disk in TBs) | VMs<br />(CPUs) | VMs<br />(memory in GBs) |
 | --- | :-: | :-: | :-: | :-: | :-: |


### PR DESCRIPTION
## Summary

The **Large** setup description states it is *"Prepared to index all currently used Subgraphs"* — this is no longer accurate and is misleading to indexers planning their infrastructure.

**The problem:**
- These figures were written when the network had far fewer subgraphs
- The network now has **15,000+ Subgraphs** (as of 2026)
- Community operators report **~600 GB total RAM for ~1,700 Subgraphs** (data from Marc-André / Ellipfra, April 2026)
- The Large tier (468 GB Postgres + 184 GB VMs = ~652 GB total) covers roughly 1,500–2,000 Subgraphs, not the full network

**The fix:**
Updated the Large tier description to accurately reflect ~1,500–2,000 Subgraph capacity and note that full-network indexing requires substantially more resources.

## Supporting data

- Community operator data: ~600 GB RAM for ~1,700 Subgraphs (Marc-André | Ellipfra, April 2026)
- Analysis: https://www.lodestar-dashboard.com/blog/indexer-memory-1000-subgraphs

The table values (CPUs, disk) are left unchanged — only the description was inaccurate.