### PR TITLE
Change Sei Docs Link

### DIFF
--- a/website/src/supportedNetworks/utils.ts
+++ b/website/src/supportedNetworks/utils.ts
@@ -44,6 +44,7 @@ export async function getSupportedNetworks() {
       return [
         {
           ...network,
+          ...(network.id === 'sei-mainnet' ? { docsUrl: 'https://docs.sei.io' } : {}),
           evm: isEvm(network),
           iconVariant: getIconVariant(network),
           subgraphsSupportLevel,


### PR DESCRIPTION
## Summary
- Update the rendered Sei mainnet docs link to https://docs.sei.io
- Keep the override scoped to the Sei supported-network entry

## Validation
- pnpm install --frozen-lockfile
- pnpm build
- Verified the built Sei page contains docs.sei.io