### PR TITLE
docs(x402): note v2 Payment-Signature header + payment-on-failure caveats

### DIFF
--- a/website/src/pages/en/subgraphs/guides/x402-payments.mdx
+++ b/website/src/pages/en/subgraphs/guides/x402-payments.mdx
@@ -81,7 +81,9 @@ The USDC payment is still settled — there is no refund. To avoid charging for 
 ```graphql
 {
   subgraphDeployment(id: "<ipfsHash>") {
-    indexerAllocations(where: { activeForIndexer_not: null }, first: 1) { id }
+    indexerAllocations(where: { activeForIndexer_not: null }, first: 1) {
+      id
+    }
   }
 }
 ```

--- a/website/src/pages/en/subgraphs/guides/x402-payments.mdx
+++ b/website/src/pages/en/subgraphs/guides/x402-payments.mdx
@@ -25,6 +25,8 @@ The existing API-key endpoints continue to work unchanged with x402 is an additi
 3. The client signs a USDC payment payload and retries the request with the payment header.
 4. The Gateway verifies the payment via a facilitator and returns the query result.
 
+> **Protocol version:** The gateway implements **x402 v2**. The signed payment payload must be sent in a `Payment-Signature` header (base64-encoded JSON containing `x402Version`, `accepted`, and `payload`). x402 v1 clients that send only `X-PAYMENT` will receive `402 Payment-Signature header is required` even after signing — use a v2-aware client such as `@graphprotocol/client-x402` or upgrade your SDK.
+
 ## Network Environments
 
 | Environment | Base URL | Payment Network | USDC Token Address |
@@ -63,6 +65,32 @@ x402 is well suited to:
 - **Integrations that prefer HTTP-native payment** over account creation and key management
 
 For sustained, high-volume application use, the existing API-key flow remains the recommended path.
+
+## Caveats
+
+### Payment applies even when no indexer is serving the Subgraph
+
+A valid `subgraph_id` or `deployment_id` is not a guarantee that any indexer is currently allocated to it. When no indexer is serving the deployment, the gateway responds with `200 OK` and the payload:
+
+```json
+{ "errors": [{ "message": "subgraph not found: no allocations" }] }
+```
+
+The USDC payment is still settled — there is no refund. To avoid charging for known-unserved deployments, check active allocations against the Graph Network Subgraph before paying:
+
+```graphql
+{
+  subgraphDeployment(id: "<ipfsHash>") {
+    indexerAllocations(where: { activeForIndexer_not: null }, first: 1) { id }
+  }
+}
+```
+
+If `indexerAllocations` is empty, no one is serving it — paying will produce the error above. Agent-side discovery layers should treat "0 active allocations" as an unservable Subgraph and either skip it or surface the warning.
+
+### Errors still cost USDC
+
+Any response from the gateway that includes a `Payment-Response` header has been settled on-chain. This includes responses containing GraphQL `errors` (bad query shape, missing fields, schema mismatch, "no allocations", etc.). Validate queries against `get_schema_by_subgraph_id` or a cached schema before paying.
 
 ## Minimal Examples
 


### PR DESCRIPTION
## Summary

Two real footguns hitting agent integrators of the `/api/x402/...` endpoints that aren't covered in the current guide:

### 1. Protocol version (v2 header)

The gateway implements **x402 v2** — payments must be sent in a `Payment-Signature` header, not v1's `X-PAYMENT`. Verified live against `gateway.thegraph.com/api/x402/subgraphs/id/5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV`:

- `X-PAYMENT: <base64>` → `402 Payment-Signature header is required`
- `Payment-Signature: <base64>` → `200 OK` with data

The current line _"Any x402 tooling that supports exact scheme will work with the gateway's x402 endpoints"_ is misleading for v1 SDKs, which sign correctly but still get 402'd. The added callout under **How It Works** points v1 users at `@graphprotocol/client-x402` or a v2-aware upgrade.

### 2. Payment-on-failure cases

USDC settles even when the gateway returns no usable data:

- **Zero active allocations.** Valid `subgraph_id` whose deployment has no indexer allocations returns `{"errors":[{"message":"subgraph not found: no allocations"}]}` with payment settled.
- **GraphQL errors.** Any response with `errors` (bad query shape, schema mismatch, etc.) is also settled.

Added a `## Caveats` section so agent integrators know to pre-check active allocations against the Graph Network Subgraph, and to validate query shape against `get_schema_by_subgraph_id` before paying. Both can be done cheaply / for free and avoid burning real USDC.

## Test plan

- [x] Live-tested `Payment-Signature` against four deployments (Uniswap V3 on ETH/Polygon/Arbitrum/Base) — all returned 200 + data after settlement; one returned errors after settlement (different schema variant), confirming the "errors still cost" point.
- [x] Reproduced "no allocations" against `QmWFi6uciaQPQmo1xRrahNwfiWLGeN9GTDJMuCfV8iVXSe` (Substreams Uniswap v3 Ethereum) — valid registry ID, no active indexers, $0.01 settled with no data.
- [ ] Reviewer to confirm wording matches Graph docs style.