### PR TITLE
Update fair use with sync rate req

### DIFF
--- a/website/src/pages/en/subgraphs/fair-use-policy.mdx
+++ b/website/src/pages/en/subgraphs/fair-use-policy.mdx
@@ -26,10 +26,7 @@ Beyond that, pricing is variable and adjusts based on usage patterns, network co
 
 #### **Syncing Limits**
 
-Subgraphs must sync within **14 days** of deployment.
-Subgraphs older than 14 days that fall significantly behind chainhead — at least 2,000 blocks behind with sustained outlier lag — may be deleted, even if they previously synced successfully.
-
-
+Subgraphs must sync within **14 days** of deployment. Subgraphs older than 14 days that fall significantly behind chainhead — at least 2,000 blocks behind with sustained outlier lag — may be deleted, even if they previously synced successfully within 14 days.
 
 > You can monitor your usage to avoid surpassing limits via [Subgraph Studio](https://thegraph.com/studio/).
 

--- a/website/src/pages/en/subgraphs/fair-use-policy.mdx
+++ b/website/src/pages/en/subgraphs/fair-use-policy.mdx
@@ -47,7 +47,7 @@ The Edge & Node Support Team reserves the right to revise fair limits or impose 
 If you exceed your fair use limits, you will receive an email alert giving you a grace period of **7 days** to take action. Here are some options:
 
 - Try [pruning Subgraph data](/subgraphs/best-practices/pruning/) to remove unused entities and help stay within storage limits.
-- If your subgraph references chains that receive indexing rewards, [indicated by double check marks in the Subgraphs column here](/subgraphs/best-practices/pruning/), then [publish your Subgraph to the Network](/subgraphs/developing/publishing/publishing-a-subgraph/#adding-signal-to-your-subgraph) and [add signal](/subgraphs/developing/publishing/publishing-a-subgraph/#adding-signal-to-your-subgraph) to encourage other Indexers on the network to serve it.
+- If your subgraph references chains that receive indexing rewards, [indicated by double check marks in the Subgraphs column here](/supported-networks/), then [publish your Subgraph to the Network](/subgraphs/developing/publishing/publishing-a-subgraph/#adding-signal-to-your-subgraph) and [add signal](/subgraphs/developing/publishing/publishing-a-subgraph/#adding-signal-to-your-subgraph) to encourage other Indexers on the network to serve it.
 - If your Subgraph references a chain that **does not** receive indexing rewards, reach out to InfraDAO [indexing@infradao.com⁠] or @jmulq on Telegram to discuss options that meet your technical needs.
 
 Edge & Node's team is committed to helping users avoid unnecessary interruptions and will continue to support all builders.

--- a/website/src/pages/en/subgraphs/fair-use-policy.mdx
+++ b/website/src/pages/en/subgraphs/fair-use-policy.mdx
@@ -27,6 +27,9 @@ Beyond that, pricing is variable and adjusts based on usage patterns, network co
 #### **Syncing Limits**
 
 Subgraphs must sync within **14 days** of deployment.
+Subgraphs older than 14 days that fall significantly behind chainhead — at least 2,000 blocks behind with sustained outlier lag — may be deleted, even if they previously synced successfully.
+
+
 
 > You can monitor your usage to avoid surpassing limits via [Subgraph Studio](https://thegraph.com/studio/).
 
@@ -36,7 +39,8 @@ To preserve the stability of Edge & Node's Subgraph Studio and the reliability o
 
 - **Storage** usage beyond posted limits. This includes circumvention of storage thresholds (e.g., use of multiple free-tier accounts).
 - **Utilization** that is abnormally high, or zero utilization, or sustained bandwidth.
-- **Sync** time greater than 14 days after deployment.
+- **Sync time** greater than 14 days after deployment.
+- **Sync rate** that is a sustained outlier for the chain, over 14 days old, and at least 2,000 blocks behind chainhead.
 
 The Edge & Node Support Team reserves the right to revise fair limits or impose temporary constraints for operational integrity.
 


### PR DESCRIPTION
- Make sure sync rate for Subgraphs (over 14 days old, over 2k blocks behind chainhead) is explicitly declared a fair use violation
- Fix link to supported networks page