### PR TITLE
docs(delegating): clarify actively-earning delegation as the APR/APY denominator

### DIFF
--- a/website/src/pages/en/resources/roles/delegating/delegating.mdx
+++ b/website/src/pages/en/resources/roles/delegating/delegating.mdx
@@ -146,6 +146,23 @@ This gives the Delegator a share of the pool:
 
 > The formula above shows that it is possible for an Indexer offering only 20% to Delegators to provide a better reward than an Indexer giving 90%. Simply do the math to determine the best reward.
 
+### Measuring actively-earning delegation
+
+When estimating APR or APY, divide rewards by the delegation that is **actively earning** — not by the Indexer's raw delegated total.
+
+When a Delegator undelegates, their GRT enters the 28-day thawing period and stops earning rewards. These tokens remain counted in the delegation pool's total balance even after thawing completes, right up until they are explicitly withdrawn. Dividing rewards by the raw delegated total therefore **understates** the real return, and the effect grows the longer withdrawals are deferred.
+
+The actively-earning base excludes thawing tokens:
+
+```
+activeDelegation = delegatedTokens - thawingTokens
+```
+
+- **On-chain:** call `getDelegatedTokensAvailable(serviceProvider, verifier)` on the HorizonStaking contract — it already excludes thawing delegation (including thawed-but-not-yet-withdrawn tokens).
+- **Network subgraph:** compute `Provision.delegatedTokens - Provision.delegatedThawingTokens`.
+
+Use this value as the denominator when calculating delegation APR/APY.
+
 ## Delegator FAQs and Bugs
 
 ### MetaMask "Pending Transaction" Bug


### PR DESCRIPTION
## Summary

Adds a short subsection to the Delegating guide clarifying that delegation APR/APY should be measured against **actively-earning** delegation (`delegatedTokens − thawingTokens`), not the raw delegated total.

## Why

When a delegator undelegates, their GRT thaws for 28 days and stops earning rewards — but those tokens remain counted in the delegation pool's total balance even after thawing completes, until they are explicitly withdrawn. Consumers that divide rewards by the raw delegated total therefore systematically **understate** returns.

This was raised on the forum ([Accurately Representing Delegated GRT in APR/APY Calculations](https://forum.thegraph.com/t/accurately-representing-delegated-grt-in-apr-apy-calculations/6924)) and confirmed by the core team as a consumer-side calculation issue rather than a protocol one. Graph Explorer has been patched accordingly; this doc change helps other integrators avoid the same footgun.

## Change

One new subsection under *Calculating Delegators Expected Return*, pointing at:
- the on-chain getter `getDelegatedTokensAvailable(serviceProvider, verifier)`, and
- the equivalent network-subgraph computation `Provision.delegatedTokens − Provision.delegatedThawingTokens`.

Both exist today; no protocol or schema dependency.
