### PR TITLE
updated tap verifier arbone mainnet contract

### DIFF
--- a/website/src/pages/en/indexing/tap.mdx
+++ b/website/src/pages/en/indexing/tap.mdx
@@ -54,7 +54,7 @@ The tap-agent automatically reconciles RAV redemptions using the network subgrap
 
 | Contract         | Arbitrum Mainnet (42161)                     | Arbitrum Sepolia (421614)                    |
 | ---------------- | -------------------------------------------- | -------------------------------------------- |
-| TAP Verifier     | `0x8f69F5C07477Ac46FBc491B1E6D91E2be0111A9e` | `0x382863e7B662027117449bd2c49285582bbBd21B` |
+| TAP Verifier     | `0x8f69F5C07477Ac46FBc491B1E6D91E2bb0111A9e` | `0x382863e7B662027117449bd2c49285582bbBd21B` |
 | Subgraph Service | `0xb2Bb92d0DE618878E438b55D5846cfecD9301105` | `0xc24A3dAC5d06d771f657A48B20cE1a671B78f26b` |
 | TAP Escrow       | `0x8f477709eF277d4A880801D01A140a9CF88bA0d3` | `0x1e4dC4f9F95E102635D8F7ED71c5CdbFa20e2d02` |
 


### PR DESCRIPTION
Updated `0x8f69F5C07477Ac46FBc491B1E6D91E2be0111A9e` to `0x8f69F5C07477Ac46FBc491B1E6D91E2bb0111A9e` in the Indexer/TAP Docs