### PR TITLE
Horizon contracts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@graphprotocol/address-book':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@graphprotocol/contracts':
         specifier: ^7.3.0
         version: 7.3.0
@@ -1407,6 +1410,9 @@ packages:
 
   '@formatjs/intl-localematcher@0.5.10':
     resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
+
+  '@graphprotocol/address-book@1.2.0':
+    resolution: {integrity: sha512-eJgZ0b/BSe3tzXRbrIImjh63NfGwZ3BA71TESvDWE6tB84D6PqbZ7/E4cA1VLPQi3ge1DQ8I+LpypjDOjhKp2A==}
 
   '@graphprotocol/contracts@7.3.0':
     resolution: {integrity: sha512-uEjgrBN4WCkJhSrUi5O64cNbU5OWI7iwy/03Er9n+J7o3WEspizpLJvSGXql8E0XtI0ygBaHBTwJfPo7SUphkg==}
@@ -9086,6 +9092,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@graphprotocol/address-book@1.2.0': {}
+
   '@graphprotocol/contracts@7.3.0': {}
 
   '@graphql-typed-document-node/core@3.2.0(graphql@16.14.0)':
@@ -10238,7 +10246,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -11071,6 +11079,11 @@ snapshots:
   abbrev@2.0.0: {}
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.25.76
+
+  abitype@1.2.4(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
       zod: 3.25.76
@@ -14571,7 +14584,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.4(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3

--- a/website/package.json
+++ b/website/package.json
@@ -22,6 +22,7 @@
     "@edgeandnode/gds": "^6.9.0",
     "@edgeandnode/go": "^10.5.1",
     "@emotion/react": "^11.14.0",
+    "@graphprotocol/address-book": "^1.2.0",
     "@graphprotocol/contracts": "^7.3.0",
     "@pinax/graph-networks-registry": "^0.7.1",
     "@react-hookz/web": "^25.2.0",

--- a/website/src/contracts.tsx
+++ b/website/src/contracts.tsx
@@ -1,4 +1,7 @@
 import ContractAddresses from '@graphprotocol/contracts/addresses.json'
+import HorizonAddresses from '@graphprotocol/address-book/horizon/addresses.json'
+import IssuanceAddresses from '@graphprotocol/address-book/issuance/addresses.json'
+import SubgraphServiceAddresses from '@graphprotocol/address-book/subgraph-service/addresses.json'
 
 import { getAddressLink } from '@edgeandnode/common'
 import { ExperimentalLink } from '@edgeandnode/gds'
@@ -7,14 +10,38 @@ import { Table } from '@/components'
 import { useI18n } from '@/i18n'
 
 type ValueOf<T> = T[keyof T]
+
+/**
+ * Legacy protocol contracts (Ethereum Mainnet, Sepolia) sourced from `@graphprotocol/contracts`.
+ * The new Horizon deployments on Arbitrum live in `@graphprotocol/address-book` (see below).
+ */
 const contractsByNetworkId = ContractAddresses as Record<string, ValueOf<typeof ContractAddresses>>
 
-export function ProtocolContractsTable({ networkId }: { networkId: number }) {
+/**
+ * Horizon-era contracts (Arbitrum One, Arbitrum Sepolia) sourced from `@graphprotocol/address-book`.
+ * Each package file is keyed by chain ID, then by contract name. Reading straight from the package
+ * means new deployments are picked up automatically whenever the dependency is bumped.
+ */
+type AddressBookEntry = { address: string }
+type AddressBook = Record<string, Record<string, AddressBookEntry>>
+
+export const addressBookPackages = {
+  horizon: HorizonAddresses as AddressBook,
+  'subgraph-service': SubgraphServiceAddresses as AddressBook,
+  issuance: IssuanceAddresses as AddressBook,
+}
+
+export type AddressBookPackage = keyof typeof addressBookPackages
+
+/** Shared name + address table used by both the legacy and address-book sources. */
+function ContractsTable({
+  networkId,
+  contracts,
+}: {
+  networkId: number
+  contracts: { name: string; address: string }[]
+}) {
   const { t } = useI18n()
-  const contracts = Object.entries(contractsByNetworkId[`${networkId}`] ?? {}).map(([name, contract]) => ({
-    ...contract,
-    name,
-  }))
   return (
     <Table>
       <tbody>
@@ -33,4 +60,23 @@ export function ProtocolContractsTable({ networkId }: { networkId: number }) {
       </tbody>
     </Table>
   )
+}
+
+/** Legacy protocol contracts for a given network, from `@graphprotocol/contracts`. */
+export function ProtocolContractsTable({ networkId }: { networkId: number }) {
+  const contracts = Object.entries(contractsByNetworkId[`${networkId}`] ?? {}).map(([name, contract]) => ({
+    name,
+    address: contract.address,
+  }))
+  return <ContractsTable networkId={networkId} contracts={contracts} />
+}
+
+/** Horizon-era contracts for a given network and package, from `@graphprotocol/address-book`. */
+export function HorizonContractsTable({ networkId, product }: { networkId: number; product: AddressBookPackage }) {
+  const contracts = Object.entries(addressBookPackages[product][`${networkId}`] ?? {}).map(([name, contract]) => ({
+    name,
+    address: contract.address,
+  }))
+  if (contracts.length === 0) return null
+  return <ContractsTable networkId={networkId} contracts={contracts} />
 }

--- a/website/src/contracts.tsx
+++ b/website/src/contracts.tsx
@@ -1,7 +1,7 @@
-import ContractAddresses from '@graphprotocol/contracts/addresses.json'
 import HorizonAddresses from '@graphprotocol/address-book/horizon/addresses.json'
 import IssuanceAddresses from '@graphprotocol/address-book/issuance/addresses.json'
 import SubgraphServiceAddresses from '@graphprotocol/address-book/subgraph-service/addresses.json'
+import ContractAddresses from '@graphprotocol/contracts/addresses.json'
 
 import { getAddressLink } from '@edgeandnode/common'
 import { ExperimentalLink } from '@edgeandnode/gds'

--- a/website/src/pages/en/contracts.mdx
+++ b/website/src/pages/en/contracts.mdx
@@ -2,15 +2,41 @@
 title: Protocol Contracts
 ---
 
-import { ProtocolContractsTable } from '@/contracts'
+import { HorizonContractsTable, ProtocolContractsTable } from '@/contracts'
 
-Below are the deployed contracts which power The Graph Network. Visit the official [contracts repository](https://github.com/graphprotocol/contracts) to learn more.
+Below are the deployed contracts which power The Graph Network. The Arbitrum contracts are sourced directly from the [`@graphprotocol/address-book`](https://www.npmjs.com/package/@graphprotocol/address-book) package, so they stay current with each release. Visit the official [contracts repository](https://github.com/graphprotocol/contracts) to learn more.
 
 ## Arbitrum One
 
 This is the principal deployment of The Graph Network.
 
-<ProtocolContractsTable networkId={42161} />
+### Horizon
+
+<HorizonContractsTable networkId={42161} product="horizon" />
+
+### Subgraph Service
+
+<HorizonContractsTable networkId={42161} product="subgraph-service" />
+
+### Issuance
+
+<HorizonContractsTable networkId={42161} product="issuance" />
+
+## Arbitrum Sepolia
+
+This is the primary testnet for The Graph Network. Testnet is predominantly used by core developers and ecosystem participants for testing purposes. There are no guarantees of service or availability on The Graph's testnets.
+
+### Horizon
+
+<HorizonContractsTable networkId={421614} product="horizon" />
+
+### Subgraph Service
+
+<HorizonContractsTable networkId={421614} product="subgraph-service" />
+
+### Issuance
+
+<HorizonContractsTable networkId={421614} product="issuance" />
 
 ## Ethereum Mainnet
 
@@ -18,12 +44,6 @@ This was the original deployment of The Graph Network. Learn more about The Grap
 
 <ProtocolContractsTable networkId={1} />
 
-## Arbitrum Sepolia
-
-This is the primary testnet for The Graph Network. Testnet is predominantly used by core developers and ecosystem participants for testing purposes. There are no guarantees of service or availability on The Graph's testnets.
-
-<ProtocolContractsTable networkId={421614} />
-
-## Sepolia
+## Ethereum Sepolia
 
 <ProtocolContractsTable networkId={11155111} />


### PR DESCRIPTION
# Source the Protocol Contracts page from `@graphprotocol/address-book`
 
## Summary
 
Drives the **Arbitrum One** and **Arbitrum Sepolia** contract tables on `/en/contracts` directly from the [`@graphprotocol/address-book`](https://www.npmjs.com/package/@graphprotocol/address-book) package instead of hardcoding addresses. Horizon-era deployments (Horizon, Subgraph Service, Issuance) now stay current with each package release — bumping the dependency is all that's needed to pick up new deployments or address changes.
 
Ethereum Mainnet and Ethereum Sepolia continue to be sourced from `@graphprotocol/contracts` as before.
 
## What changed
 
- **`website/package.json`** — added `@graphprotocol/address-book` (`^1.2.0`) as a dependency.
- **`website/src/contracts.tsx`** — refactored to a shared name/address table and added a `HorizonContractsTable` component that reads a given network + product (`horizon` / `subgraph-service` / `issuance`) straight from the address-book package. `ProtocolContractsTable` (legacy `@graphprotocol/contracts` source) is unchanged in behavior.
- **`website/src/pages/en/contracts.mdx`** — reorganized network-first with per-product sub-tables on the Arbitrum sections.
## Page structure
 
- **Arbitrum One**: Horizon, Subgraph Service, Issuance
- **Arbitrum Sepolia**: Horizon, Subgraph Service, Issuance
- **Ethereum Mainnet**: legacy protocol contracts
- **Ethereum Sepolia**: legacy protocol contracts
Tables show contract name + address (linked to the block explorer), matching the existing minimalist page.
 
## Why
 
The old page hardcoded Arbitrum addresses via `@graphprotocol/contracts/addresses.json`, which predates the Horizon migration and drifts out of date as contracts are deployed/upgraded. Reading from the maintained address-book package makes the docs self-updating for the common case (new contracts and address changes within existing products/networks).
 
## Testing
 
- `pnpm install` (updates `pnpm-lock.yaml` with the new dependency)
- `pnpm dev` → open `http://localhost:3000/en/contracts/`
- `pnpm --filter @graphprotocol/docs typecheck`
- Verified the published `@graphprotocol/address-book@1.2.0` resolves the three subpath imports, that its data matches the source repo, and that every product is populated on both Arbitrum chains (no empty tables). JSON-import typing passes `tsc` under the repo's strict settings. Prettier reports no changes.

## Notes for reviewers
 
- `L2Curation`, `L2GNS`, and `SubgraphNFT` appear in both the `horizon` and `subgraph-service` package files, so they render under both sub-sections. This faithfully mirrors the address-book; happy to de-duplicate if preferred.
- Adding a **new** product file or a **new** network still requires a small MDX edit (one new import / section); new contracts within existing products/networks are picked up automatically.
- The `@graphprotocol/address-book` version can be pinned/bumped in `website/package.json` to control which deployment set the docs reflect.